### PR TITLE
ci: run tests via GitHub Actions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,90 @@
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  tests:
+    strategy:
+      matrix:
+        env:
+          - { NPROC: 2 }
+        platform: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.platform }}
+    env: ${{ matrix.env }}
+
+    name: ${{ matrix.platform }} - ${{ matrix.env.NPROC }} processes
+
+    steps:
+      - name: Install Scoop
+        if: startsWith(matrix.platform, 'windows')
+        shell: powershell
+        run: |
+            iwr -useb get.scoop.sh | iex
+
+      - name: Install tools with Scoop
+        if: startsWith(matrix.platform, 'windows')
+        shell: bash
+        run: |
+          export PATH="${PATH}:${HOME}/scoop/shims"
+          scoop install wget
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      # We need to do this because of how github cache works
+      - name: Initialize Submodules
+        shell: bash
+        run: |
+          git submodule update --init --recursive
+
+      - name: Cache Nim compiler and status-go builds
+        uses: actions/cache@v2
+        with:
+          path: |
+            vendor/nimbus-build-system/vendor/Nim/bin
+            vendor/status-go/build/bin
+          key: ${{ runner.os }}-${{ matrix.env.NPROC }}-nim-${{ hashFiles('.gitmodules') }}
+
+      - name: Install dependencies and make default target
+        shell: bash
+        run: |
+          [[ ${{ matrix.platform }} = windows* ]] && export PATH="${PATH}:${HOME}/scoop/shims"
+          export M="$(which mingw32-make || echo make)"
+          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+          "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1
+
+      - name: Run Nim tests
+        shell: bash
+        run: |
+          [[ ${{ matrix.platform }} = windows* ]] && export PATH="${PATH}:${HOME}/scoop/shims"
+          export M="$(which mingw32-make || echo make)"
+          tester() {
+            "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 tests-nim
+          }
+          tester &
+          sleep 600
+          if [[ ${{ matrix.platform }} = windows* ]]; then
+            taskkill -IM login.exe -F
+          else
+            kill $!
+          fi
+
+      - name: Run C tests
+        shell: bash
+        run: |
+          [[ ${{ matrix.platform }} = windows* ]] && export PATH="${PATH}:${HOME}/scoop/shims"
+          export M="$(which mingw32-make || echo make)"
+          tester() {
+            "${M}" -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 tests-c
+          }
+          tester &
+          sleep 600
+          if [[ ${{ matrix.platform }} = windows* ]]; then
+            taskkill -IM login.exe -F
+          else
+            kill $!
+          fi

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ test-c-template: | $(STATUSGO) clean-data-dirs create-data-dirs
 ifeq ($(detected_OS),Darwin)
 	./tests/c/build/$(TEST_NAME)
 else ifeq ($(detected_OS),Windows)
-	PATH="$(STATUSGO_LIBDIR)":"$(NIM_WINDOWS_PREBUILT_DLLDIR)":/usr/bin:/bin:"$(PATH)" \
+	PATH="$(STATUSGO_LIBDIR):$(NIM_WINDOWS_PREBUILT_DLLDIR):/usr/bin:/bin:$$PATH" \
 	./tests/c/build/$(TEST_NAME)
 else
 	LD_LIBRARY_PATH="$(STATUSGO_LIBDIR)" \
@@ -234,7 +234,7 @@ tests-nim: | $(STATUSGO)
 ifeq ($(detected_OS),Darwin)
 	$(ENV_SCRIPT) nimble test
 else ifeq ($(detected_OS),Windows)
-	PATH="$(STATUSGO_LIBDIR)":"$(NIM_WINDOWS_PREBUILT_DLLDIR)":/usr/bin:/bin:"$(PATH)" \
+	PATH="$(STATUSGO_LIBDIR):$(NIM_WINDOWS_PREBUILT_DLLDIR):/usr/bin:/bin:$$PATH" \
 	$(ENV_SCRIPT) nimble test
 else
 	LD_LIBRARY_PATH="$(STATUSGO_LIBDIR)" \

--- a/tests/c/login.c
+++ b/tests/c/login.c
@@ -92,6 +92,7 @@ int main(int argc, char* argv[]) {
 
   while(1) {
     printf("...\n");
+    fflush(stdout);
     sleep(1);
   }
 


### PR DESCRIPTION
Until login tests are refactored, kill the Nim and C tests after they've been running for 10 minutes.

On Windows, using *Git Bash's* `kill` to stop the backround tester task doesn't work correctly; instead use Windows built-in `taskkill`.