### PR TITLE
feat: add createAccount function to create a random account

### DIFF
--- a/nim_status.nimble
+++ b/nim_status.nimble
@@ -78,3 +78,4 @@ task tests, "Run all tests":
   buildAndRunTest "mailservers"
   buildAndRunTest "bip32"
   buildAndRunTest "contacts"
+  buildAndRunTest "account"

--- a/nim_status/lib.nim
+++ b/nim_status/lib.nim
@@ -1,5 +1,6 @@
 import lib/alias
 import lib/alias/data
+import lib/account
 import lib/identicon
 import lib/util
 import nimcrypto
@@ -7,6 +8,8 @@ import strformat
 import strutils
 import unicode
 import json
+
+export createAccount 
 
 proc hashMessage*(message: string): string =
   ## hashMessage calculates the hash of a message to be safely signed by the keycard.

--- a/nim_status/lib/account.nim
+++ b/nim_status/lib/account.nim
@@ -2,7 +2,7 @@ import
   std/[parseutils, strutils],
   normalize,
   secp256k1,
-  stew/[results],
+  stew/[results, byteutils],
   nimcrypto/[sha2, pbkdf2, hash, hmac],
   account/[types, paths],
   eth/keys
@@ -75,3 +75,7 @@ proc createAccount*(rng: ref BrHmacDrbgContext): Account =
     publicKey: $publicKey,
     privateKey: $privateKey
   )
+
+proc derivePubKeyFromPrivateKey*(privateKey: string): string =
+  var privKey = PrivateKey.fromRaw(hexToSeqByte(privateKey)).get()
+  return $privKey.toPublicKey()

--- a/nim_status/lib/account.nim
+++ b/nim_status/lib/account.nim
@@ -4,7 +4,9 @@ import
   secp256k1,
   stew/[results],
   nimcrypto/[sha2, pbkdf2, hash, hmac],
-  account/[types, paths]
+  account/[types, paths],
+  eth/keys
+import ../types
 
 export KeySeed, Mnemonic, SecretKeyResult, KeyPath
 
@@ -59,4 +61,17 @@ proc derive*(seed: Keyseed, path: KeyPath): SecretKeyResult =
 
   ok(extPrivK.secretKey)
 
+# Creates a new random account with its private key, public key and address
+# rng: use a single RNG instance for the application - will be seeded on construction
+    # and avoid using system resources (such as urandom) after that
+    # To create, just do: `keys.newRng()`
+proc createAccount*(rng: ref BrHmacDrbgContext): Account =
+  let privateKey = PrivateKey.random(rng[])
+  let publicKey = privateKey.toPublicKey()
+  let address = publicKey.toAddress()
 
+  result = Account(
+    address: address,
+    publicKey: $publicKey,
+    privateKey: $privateKey
+  )

--- a/nim_status/lib/account.nim
+++ b/nim_status/lib/account.nim
@@ -6,7 +6,7 @@ import
   nimcrypto/[sha2, pbkdf2, hash, hmac],
   account/[types, paths],
   eth/keys
-import ../types
+import ../types as t
 
 export KeySeed, Mnemonic, SecretKeyResult, KeyPath
 
@@ -77,5 +77,12 @@ proc createAccount*(rng: ref BrHmacDrbgContext): Account =
   )
 
 proc derivePubKeyFromPrivateKey*(privateKey: string): string =
-  var privKey = PrivateKey.fromRaw(hexToSeqByte(privateKey)).get()
+  let privKey = PrivateKey.fromRaw(hexToSeqByte(privateKey)).get()
   return $privKey.toPublicKey()
+
+proc signMessage*(privateKey: string, message: string): string =
+  let privKey = PrivateKey.fromRaw(hexToSeqByte(privateKey)).get()
+
+  let bytesMsg = message.toBytes()
+
+  return $keys.sign(privKey, bytesMsg)

--- a/nim_status/types.nim
+++ b/nim_status/types.nim
@@ -1,1 +1,7 @@
 type SignalCallback* = proc(eventMessage: cstring): void {.cdecl.}
+
+type Account* = ref object
+  address*: string
+  publicKey*: string
+  privateKey*: string
+  

--- a/test/nim/account.nim
+++ b/test/nim/account.nim
@@ -1,0 +1,28 @@
+import ../../nim_status/lib/account
+import test_helpers
+import utils
+import eth/[keys, p2p]
+
+import chronos
+import os
+import unittest
+
+var success = false
+
+
+procSuite "nim_status":
+  asyncTest "account":
+    resetDirectories() # Recreates the data and nobackup dir
+    init()
+
+    # Single RNG instance for the application - will be seeded on construction
+    # and avoid using system resources (such as urandom) after that
+    var rng = keys.newRng()
+
+    let account = createAccount(rng)
+
+    check:
+      account.address != ""
+      account.publicKey != ""
+      account.privateKey != ""
+

--- a/test/nim/account.nim
+++ b/test/nim/account.nim
@@ -25,9 +25,12 @@ procSuite "nim_status":
     let pubKey = derivePubKeyFromPrivateKey(account.privateKey)
 
 
+    let signature = signMessage(account.privateKey, "Hello world")
+
     check:
       account.address != ""
       account.publicKey != ""
       account.privateKey != ""
       account.publicKey == pubKey
+      signature != ""
 

--- a/test/nim/account.nim
+++ b/test/nim/account.nim
@@ -21,8 +21,13 @@ procSuite "nim_status":
 
     let account = createAccount(rng)
 
+
+    let pubKey = derivePubKeyFromPrivateKey(account.privateKey)
+
+
     check:
       account.address != ""
       account.publicKey != ""
       account.privateKey != ""
+      account.publicKey == pubKey
 


### PR DESCRIPTION
Adds the createAccount function to create a random account from  a random private Key.

Returns it as an Account object containing the private key, public key and address.

The function must be called with an `rng` object that should be generated on app start so that it can be reused  avoid using system resources (such as urandom) after that (explanation taken from the nim-eth repo