### PR TITLE
feat: bump nim-sqlcipher to version with updated apis

### DIFF
--- a/nim_status/lib/conversions.nim
+++ b/nim_status/lib/conversions.nim
@@ -2,10 +2,16 @@ import
   json, options
 
 import
-  web3/ethtypes, sqlcipher
+  web3/ethtypes, sqlcipher, json_serialization, stew/byteutils
 
 proc parseAddress*(strAddress: string): Address =
   fromHex(Address, strAddress)
+
+proc toDbValue*[T: Address](val: T): DbValue =
+  DbValue(kind: sqliteText, strVal: $val)
+
+proc toDbValue*(val: JsonNode): DbValue =
+  DbValue(kind: sqliteText, strVal: $val)
 
 proc fromDbValue*(val: DbValue, T: typedesc[JsonNode]): JsonNode = val.strVal.parseJson
 

--- a/nim_status/lib/database.nim
+++ b/nim_status/lib/database.nim
@@ -1,59 +1,64 @@
-import sqlcipher
+import # nim libs
+  strformat
+
+import # vendor libs
+  sqlcipher, settings/types
 
 proc migrate*(db: DbConn) =
   # TODO: implement proper migrations
   # Remove this query. Use status-go appdatabase/migrations/sql files instead
-  let settingSQL = """CREATE TABLE settings (
-                        address VARCHAR NOT NULL,
-                        chaos_mode BOOLEAN DEFAULT false,
-                        currency VARCHAR DEFAULT 'usd',
-                        current_network VARCHAR NOT NULL,
-                        custom_bootnodes BLOB,
-                        custom_bootnodes_enabled BLOB,
-                        dapps_address VARCHAR NOT NULL,
-                        eip1581_address VARCHAR,
-                        fleet VARCHAR,
-                        hide_home_tooltip BOOLEAN DEFAULT false,
-                        installation_id VARCHAR NOT NULL,
-                        key_uid VARCHAR NOT NULL,
-                        keycard_instance_uid VARCHAR,
-                        keycard_paired_on UNSIGNED BIGINT,
-                        keycard_pairing VARCHAR,
-                        last_updated UNSIGNED BIGINT,
-                        latest_derived_path UNSIGNED INT DEFAULT 0,
-                        log_level VARCHAR,
-                        mnemonic VARCHAR,
-                        name VARCHAR NOT NULL,
-                        networks BLOB NOT NULL,
-                        node_config BLOB,
-                        notifications_enabled BOOLEAN DEFAULT false,
-                        photo_path BLOB NOT NULL,
-                        pinned_mailservers BLOB,
-                        preferred_name VARCHAR,
-                        preview_privacy BOOLEAN DEFAULT false,
-                        public_key VARCHAR NOT NULL,
-                        remember_syncing_choice BOOLEAN DEFAULT false,
-                        signing_phrase VARCHAR NOT NULL,
-                        stickers_packs_installed BLOB,
-                        stickers_recent_stickers BLOB,
-                        syncing_on_mobile_network BOOLEAN DEFAULT false,
+  var settings: Settings
+  let settingSQL = fmt"""CREATE TABLE {settings.tableName} (
+                        {settings.userAddress.columnName} VARCHAR NOT NULL,
+                        {settings.chaosMode.columnName} BOOLEAN DEFAULT 0,
+                        {settings.currency.columnName} VARCHAR DEFAULT 'usd',
+                        {settings.currentNetwork.columnName} VARCHAR NOT NULL,
+                        {settings.customBootnodes.columnName} BLOB,
+                        {settings.customBootnodes_enabled.columnName} BLOB,
+                        {settings.dappsAddress.columnName} VARCHAR NOT NULL,
+                        {settings.eip1581Address.columnName} VARCHAR,
+                        {settings.fleet.columnName} VARCHAR,
+                        {settings.hideHomeTooltip.columnName} BOOLEAN DEFAULT 0,
+                        {settings.installationId.columnName} VARCHAR NOT NULL,
+                        {settings.keyUid.columnName} VARCHAR NOT NULL,
+                        {settings.keycardInstance_uid.columnName} VARCHAR,
+                        {settings.keycardPairedOn.columnName} UNSIGNED BIGINT,
+                        {settings.keycardPairing.columnName} VARCHAR,
+                        {settings.lastUpdated.columnName} UNSIGNED BIGINT,
+                        {settings.latestDerivedPath.columnName} UNSIGNED INT DEFAULT 0,
+                        {settings.logLevel.columnName} VARCHAR,
+                        {settings.mnemonic.columnName} VARCHAR,
+                        {settings.name.columnName} VARCHAR NOT NULL,
+                        {settings.networks.columnName} BLOB NOT NULL,
+                        {settings.nodeConfig.columnName} BLOB,
+                        {settings.notificationsEnabled.columnName} BOOLEAN DEFAULT 0,
+                        {settings.photoPath.columnName} BLOB NOT NULL,
+                        {settings.pinnedMailservers.columnName} BLOB,
+                        {settings.preferredName.columnName} VARCHAR,
+                        {settings.previewPrivacy.columnName} BOOLEAN DEFAULT 0,
+                        {settings.publicKey.columnName} VARCHAR NOT NULL,
+                        {settings.rememberSyncing_choice.columnName} BOOLEAN DEFAULT 0,
+                        {settings.signingPhrase.columnName} VARCHAR NOT NULL,
+                        {settings.stickerPacksInstalled.columnName} BLOB,
+                        {settings.stickersRecentStickers.columnName} BLOB,
+                        {settings.syncingOnMobileNetwork.columnName} BOOLEAN DEFAULT 0,
                         synthetic_id VARCHAR DEFAULT 'id' PRIMARY KEY,
-                        usernames BLOB,
-                        wallet_root_address VARCHAR NOT NULL,
-                        wallet_set_up_passed BOOLEAN DEFAULT false,
-                        wallet_visible_tokens VARCHAR
+                        {settings.usernames.columnName} BLOB,
+                        {settings.walletRootAddress.columnName} VARCHAR NOT NULL,
+                        {settings.walletSetUpPassed.columnName} BOOLEAN DEFAULT 0,
+                        {settings.walletVisibleTokens.columnName} VARCHAR
                       ) WITHOUT ROWID;
-                      ALTER TABLE settings ADD COLUMN stickers_packs_pending BLOB;
-                      ALTER TABLE settings ADD COLUMN waku_enabled BOOLEAN DEFAULT false;
-                      ALTER TABLE settings ADD COLUMN waku_bloom_filter_mode BOOLEAN DEFAULT false;
-                      ALTER TABLE settings ADD COLUMN appearance INT NOT NULL DEFAULT 0;
-                      ALTER TABLE settings ADD COLUMN remote_push_notifications_enabled BOOLEAN DEFAULT FALSE;
-                      ALTER TABLE settings ADD COLUMN send_push_notifications BOOLEAN DEFAULT TRUE;
-                      ALTER TABLE settings ADD COLUMN push_notifications_server_enabled BOOLEAN DEFAULT FALSE;
-                      ALTER TABLE settings ADD COLUMN push_notifications_from_contacts_only BOOLEAN DEFAULT FALSE;
-                      ALTER TABLE settings ADD COLUMN push_notifications_block_mentions BOOLEAN DEFAULT FALSE;
-                      ALTER TABLE settings ADD COLUMN webview_allow_permission_requests BOOLEAN DEFAULT FALSE;
-                      ALTER TABLE settings ADD COLUMN use_mailservers BOOLEAN DEFAULT TRUE;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.stickersPacksPending.columnName} BLOB;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.wakuEnabled.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.wakuBloomFilterMode.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.appearance.columnName} INT NOT NULL DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.remotePushNotificationsEnabled.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.sendPushNotifications.columnName} BOOLEAN DEFAULT 1;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.pushNotificationsServerEnabled.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.pushNotificationsFromContactsOnly.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.pushNotificationsBlockMentions.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.webviewAllowPermissionRequests.columnName} BOOLEAN DEFAULT 0;
+                      ALTER TABLE {settings.tableName} ADD COLUMN {settings.useMailservers.columnName} BOOLEAN DEFAULT 1;
                       """
   db.execScript(settingSQL)
 

--- a/nim_status/lib/settings.nim
+++ b/nim_status/lib/settings.nim
@@ -1,5 +1,5 @@
 import # nim libs
-  json, options, strutils, locks
+  json, options, strutils, locks, strformat
 
 import # vendor libs
   web3/conversions as web3_conversions, web3/ethtypes, sqlcipher
@@ -21,169 +21,43 @@ proc createSettings*(db: DbConn, s: Settings, nodecfg: JsonNode) = # TODO: repla
                 VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,'id')"""
 
   db.exec(query,
-            $s.userAddress,
-            (if s.currency.isSome(): s.currency.get() else: ""),
+            s.userAddress,
+            s.currency,
             s.currentNetwork,
-            $s.dappsAddress,
-            $s.eip1581Address,
+            s.dappsAddress,
+            s.eip1581Address,
             s.installationID,
             s.keyUID,
-            (if s.keycardInstanceUID.isSome(): s.keycardInstanceUID.get() else: ""),
-            (if s.keycardPairedOn.isSome(): s.keycardPairedOn.get() else: 0),
-            (if s.keycardPairing.isSome(): s.keycardPairing.get() else: ""),
+            s.keycardInstanceUID,
+            s.keycardPairedOn,
+            s.keycardPairing,
             s.latestDerivedPath,
             s.mnemonic,
-            (if s.name.isSome(): s.name.get() else: ""),
-            $s.networks,
-            $nodecfg,
+            s.name,
+            s.networks,
+            nodecfg,
             s.photoPath,
             s.previewPrivacy,
             s.publicKey,
             s.signingPhrase,
-            (if s.walletRootAddress.isSome(): $s.walletRootAddress.get() else: ""))
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: bool) =
-  case setting
-  of SettingsType.ChaosMode:
-    db.exec("UPDATE settings SET chaos_mode = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.HideHomeToolTip:
-    db.exec("UPDATE settings SET hide_home_tooltip = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PreviewPrivacy:
-    db.exec("UPDATE settings SET preview_privacy = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.SyncingOnMobileNetwork:
-    db.exec("UPDATE settings SET syncing_on_mobile_network = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.RememberSyncingChoice:
-    db.exec("UPDATE settings SET remember_syncing_choice = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.RemotePushNotificationsEnabled:
-    db.exec("UPDATE settings SET remote_push_notifications_enabled = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PushNotificationsServerEnabled:
-    db.exec("UPDATE settings SET push_notifications_server_enabled = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PushNotificationsFromContactsOnly:
-    db.exec("UPDATE settings SET push_notifications_from_contacts_only = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PushNotificationsBlockMentions:
-    db.exec("UPDATE settings SET push_notifications_block_mentions = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.SendPushNotifications:
-    db.exec("UPDATE settings SET send_push_notifications = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.UseMailservers:
-    db.exec("UPDATE settings SET use_mailservers = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.NotificationsEnabled:
-    db.exec("UPDATE settings SET notifications_enabled = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.WakuEnabled:
-    db.exec("UPDATE settings SET waku_enabled = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.WalletSetupPassed:
-    db.exec("UPDATE settings SET wallet_set_up_passed = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.WakuBloomFilterMode:
-    db.exec("UPDATE settings SET waku_bloom_filter_mode = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.WebviewAllowPermissionRequests:
-    db.exec("UPDATE settings SET webview_allow_permission_requests = ? WHERE synthetic_id = 'id'", value)
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: int64) =
-  case setting
-  of SettingsType.Keycard_PairedOn:
-    db.exec("UPDATE settings SET keycard_paired_on = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.LastUpdated:
-    db.exec("UPDATE settings SET last_updated = ? WHERE synthetic_id = 'id'", value)
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: int) =
-  case setting
-  of SettingsType.LatestDerivedPath:
-    db.exec("UPDATE settings SET latest_derived_path = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.Appearance:
-    db.exec("UPDATE settings SET appearance = ? WHERE synthetic_id = 'id'", value)
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: string) =
-  case setting
-  of SettingsType.Currency:
-    db.exec("UPDATE settings SET currency = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.Fleet:
-    db.exec("UPDATE settings SET fleet = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.KeycardInstanceUID:
-    db.exec("UPDATE settings SET keycard_instance_uid = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.Keycard_Pairing:
-    db.exec("UPDATE settings SET keycard_pairing = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.LogLevel:
-    db.exec("UPDATE settings SET log_level = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.Mnemonic:
-    db.exec("UPDATE settings SET mnemonic = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.Name:
-    db.exec("UPDATE settings SET name = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.CurrentNetwork:
-    db.exec("UPDATE settings SET current_network = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PhotoPath:
-    db.exec("UPDATE settings SET photo_path = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PreferredName:
-    db.exec("UPDATE settings SET preferred_name = ? WHERE synthetic_id = 'id'", value)
-  of SettingsType.PublicKey:
-    db.exec("UPDATE settings SET public_key = ? WHERE synthetic_id = 'id'", value)
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: JsonNode) =
-  case setting
-  of SettingsType.CustomBootnodes:
-    db.exec("UPDATE settings SET custom_bootnodes = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.CustomBootnodesEnabled:
-    db.exec("UPDATE settings SET custom_bootnodes_enabled = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.Networks:
-    db.exec("UPDATE settings SET networks = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.NodeConfig:
-    db.exec("UPDATE settings SET node_config = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.PinnedMailservers:
-    db.exec("UPDATE settings SET pinned_mailservers = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.StickersPacksInstalled:
-    db.exec("UPDATE settings SET stickers_packs_installed = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.StickersPacksPending:
-    db.exec("UPDATE settings SET stickers_packs_pending = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.StickersRecentStickers:
-    db.exec("UPDATE settings SET stickers_recent_stickers = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.Usernames:
-    db.exec("UPDATE settings SET usernames = ? WHERE synthetic_id = 'id'", ($value))
-  of SettingsType.WalletVisibleTokens:
-    db.exec("UPDATE settings SET wallet_visible_tokens = ? WHERE synthetic_id = 'id'", ($value))
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
-
-proc saveSetting*(db: DbConn, setting: SettingsType, value: Address) =
-  case setting
-  of SettingsType.DappsAddress:
-    db.exec("UPDATE settings SET dapps_address = ? WHERE synthetic_id = 'id'", $value)
-  of SettingsType.EIP1581Address:
-    db.exec("UPDATE settings SET eip1581_address = ? WHERE synthetic_id = 'id'", $value)
-  else: 
-    raise (ref SettingsError)(msg: "Setting: '" & $setting & "' cannot be updated or invalid data type received")
-
+            s.walletRootAddress)
 
 proc saveSetting*(db: DbConn, setting: string, value: auto) =
-  var s: SettingsType
-  try: 
-    s = parseEnum[SettingsType](setting)
-  except:
-    raise (ref SettingsError)(msg: "Unknown setting: '" & $setting)
-
-  saveSetting(db, s, value)
-
+  var settings: Settings
+  db.exec(fmt"""UPDATE {settings.tableName} SET {setting} = ? WHERE synthetic_id = 'id'""", value)
 
 proc getNodeConfig*(db: DbConn): JsonNode =
-  let query = "SELECT node_config FROM settings WHERE synthetic_id = 'id'"
-  for r in rows(db, query):
-    return r[0].strVal.parseJson
-
+  var settings: Settings
+  let query = fmt"""SELECT {settings.nodeConfig.columnName} FROM {settings.tableName} WHERE synthetic_id = 'id'"""
+  let nodeConfig = db.value(JsonNode, query)
+  if not nodeConfig.isSome:
+    raise newException(ValueError, "No record found for node config")
+  nodeConfig.get
 
 proc getSettings*(db: DbConn): Settings =
-  let query = """SELECT * FROM settings WHERE synthetic_id = 'id'"""
+  let query = fmt"""SELECT * FROM {result.tableName} WHERE synthetic_id = 'id'"""
 
-  let settings = execQuery[Settings](db, query)
-  if settings.len == 0:
-    raise newException(ValueError, "No records found for settings")
-  settings[0]
+  let settings = db.one(Settings, query)
+  if not settings.isSome:
+    raise newException(ValueError, "No record found for settings")
+  settings.get

--- a/nim_status/lib/settings/types.nim
+++ b/nim_status/lib/settings/types.nim
@@ -82,6 +82,7 @@ type
     Name = "name",
     CurrentNetwork = "current_network",
     Networks = "networks",
+    NodeConfig = "node_config",
     NotificationsEnabled = "notifications_enabled",
     PhotoPath = "photo_path",
     PinnedMailservers = "pinned_mailservers",
@@ -109,7 +110,7 @@ type
     WakuBloomFilterMode = "waku_bloom_filter_mode",
     WebviewAllowPermissionRequests = "webview_allow_permission_requests"
 
-  Settings* = object
+  Settings* {.dbTableName("settings").} = object
     userAddress* {.serializedFieldName($SettingsType.Address), dbColumnName($SettingsCol.Address).}: Address 
     chaosMode* {.serializedFieldName($SettingsType.ChaosMode), dbColumnName($SettingsCol.ChaosMode).}: Option[bool]
     currency* {.serializedFieldName($SettingsType.Currency), dbColumnName($SettingsCol.Currency).}: Option[string]
@@ -131,6 +132,7 @@ type
     mnemonic* {.serializedFieldName($SettingsType.Mnemonic), dbColumnName($SettingsCol.Mnemonic).}: Option[string]
     name* {.serializedFieldName($SettingsType.Name), dbColumnName($SettingsCol.Name).}: Option[string]
     networks* {.serializedFieldName($SettingsType.Networks), dbColumnName($SettingsCol.Networks).}: JsonNode
+    nodeConfig* {.serializedFieldName($SettingsType.NodeConfig), dbColumnName($SettingsCol.NodeConfig).}: JsonNode
     # NotificationsEnabled indicates whether local notifications should be enabled (android only)
     notificationsEnabled* {.dontSerialize, serializedFieldName($SettingsType.NotificationsEnabled), dbColumnName($SettingsCol.NotificationsEnabled).}: Option[bool]
     photoPath* {.serializedFieldName($SettingsType.PhotoPath), dbColumnName($SettingsCol.PhotoPath).}: string

--- a/test/nim/settings.nim
+++ b/test/nim/settings.nim
@@ -2,7 +2,8 @@ import # nim libs
   os, json, options
 
 import # vendor libs
-  sqlcipher, json_serialization, web3/conversions as web3_conversions
+  sqlcipher, json_serialization, web3/conversions as web3_conversions,
+  web3/ethtypes
 
 import # nim-status libs
   ../../nim_status/lib/[settings, database, conversions]
@@ -13,6 +14,7 @@ let db = initializeDB(path, passwd)
 
 let settingsStr = """{
     "address": "0x1122334455667788990011223344556677889900",
+    "chaos-mode": true,
     "networks/current-network": "mainnet",
     "dapps-address": "0x1122334455667788990011223344556677889900",
     "eip1581-address": "0x1122334455667788990011223344556677889900",
@@ -20,13 +22,14 @@ let settingsStr = """{
     "key-uid": "XYZ",
     "latest-derived-path": 0,
     "networks/networks": [{"someNetwork": "1"}],
+    "name": "test",
     "photo-path": "ABXYZC",
     "preview-privacy?": false,
     "public-key": "0x123",
-    "signing-phrase": "ABC DEF GHI"
+    "signing-phrase": "ABC DEF GHI",
+    "wallet-root-address": "0x1122334455667788990011223344556677889900"
   }"""
-
-let settingsObj = JSON.decode(settingsStr, Settings, allowUnknownFields = true)
+let settingsObj = Json.decode(settingsStr, Settings, allowUnknownFields = true)
 
 let nodeConfig = %* {"config": 1}
 
@@ -34,10 +37,12 @@ createSettings(db, settingsObj, nodeConfig)
 
 let dbSettings1 = getSettings(db)
 
-assert $settingsObj.userAddress == $dbSettings1.userAddress
+assert settingsObj.userAddress == dbSettings1.userAddress
+assert settingsObj.chaosMode.isNone
+assert dbSettings1.chaosMode.get == false
 assert settingsObj.currentNetwork == dbSettings1.currentNetwork
-assert $settingsObj.dappsAddress == $dbSettings1.dappsAddress
-assert $settingsObj.eip1581Address == $dbSettings1.eip1581Address
+assert settingsObj.dappsAddress == dbSettings1.dappsAddress
+assert settingsObj.eip1581Address == dbSettings1.eip1581Address
 assert settingsObj.installationId == dbSettings1.installationId
 assert settingsObj.keyUID == dbSettings1.keyUID
 assert settingsObj.latestDerivedPath == dbSettings1.latestDerivedPath
@@ -55,47 +60,48 @@ let testInt:int = 1
 let testInt64:int64 = 1
 let testUint:uint = 1
 var testAddress = "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef".parseAddress
+var setting: Settings
 
-saveSetting(db, SettingsType.ChaosMode, testBool)
-saveSetting(db, SettingsType.Currency, testString)
-saveSetting(db, SettingsType.CustomBootNodes, testJSON)
-saveSetting(db, SettingsType.CustomBootNodesEnabled, testJSON)
-saveSetting(db, SettingsType.DappsAddress, testAddress)
-saveSetting(db, SettingsType.EIP1581Address, testAddress)
-saveSetting(db, SettingsType.Fleet, testString)
-saveSetting(db, SettingsType.HideHomeTooltip, testBool)
-saveSetting(db, SettingsType.KeycardInstanceUID, testString)
-saveSetting(db, SettingsType.Keycard_PairedOn, testInt64)
-saveSetting(db, SettingsType.Keycard_Pairing, testString)
-saveSetting(db, SettingsType.LastUpdated, testInt64)
-saveSetting(db, SettingsType.LatestDerivedPath, testInt)
-saveSetting(db, SettingsType.LogLevel, testString)
-saveSetting(db, SettingsType.Mnemonic, testString)
-saveSetting(db, SettingsType.Name, testString)
-saveSetting(db, SettingsType.CurrentNetwork, testString)
-saveSetting(db, SettingsType.Networks, testJSON)
-saveSetting(db, SettingsType.NodeConfig, testJSON)
-saveSetting(db, SettingsType.NotificationsEnabled, testBool)
-saveSetting(db, SettingsType.PhotoPath, testString)
-saveSetting(db, SettingsType.PinnedMailservers, testJSON)
-saveSetting(db, SettingsType.PreferredName, testString)
-saveSetting(db, SettingsType.PreviewPrivacy, testBool)
-saveSetting(db, SettingsType.PublicKey, testString)
-saveSetting(db, SettingsType.RememberSyncingChoice, testBool)
-saveSetting(db, SettingsType.RemotePushNotificationsEnabled, testBool)
-saveSetting(db, SettingsType.PushNotificationsServerEnabled, testBool)
-saveSetting(db, SettingsType.PushNotificationsFromContactsOnly, testBool)
-saveSetting(db, SettingsType.SendPushNotifications, testBool)
-saveSetting(db, SettingsType.StickersPacksInstalled, testJSON)
-saveSetting(db, SettingsType.StickersPacksPending, testJSON)
-saveSetting(db, SettingsType.StickersRecentStickers, testJSON)
-saveSetting(db, SettingsType.SyncingOnMobileNetwork, testBool)
-saveSetting(db, SettingsType.Usernames, testJSON)
-saveSetting(db, SettingsType.WalletSetupPassed, testBool)
-saveSetting(db, SettingsType.WalletVisibleTokens, testJSON)
-saveSetting(db, SettingsType.Appearance, testInt)
-saveSetting(db, SettingsType.WakuEnabled, testBool)
-saveSetting(db, SettingsType.WakuBloomFilterMode, testBool)
+saveSetting(db, setting.chaosMode.columnName, testBool)
+saveSetting(db, setting.currency.columnName, testString)
+saveSetting(db, setting.customBootNodes.columnName, testJSON)
+saveSetting(db, setting.customBootNodesEnabled.columnName, testJSON)
+saveSetting(db, setting.dappsAddress.columnName, testAddress)
+saveSetting(db, setting.eip1581Address.columnName, testAddress)
+saveSetting(db, setting.fleet.columnName, testString)
+saveSetting(db, setting.hideHomeTooltip.columnName, testBool)
+saveSetting(db, setting.keycardInstanceUID.columnName, testString)
+saveSetting(db, setting.keycardPairedOn.columnName, testInt64)
+saveSetting(db, setting.keycardPairing.columnName, testString)
+saveSetting(db, setting.lastUpdated.columnName, testInt64)
+saveSetting(db, setting.latestDerivedPath.columnName, testInt)
+saveSetting(db, setting.logLevel.columnName, testString)
+saveSetting(db, setting.mnemonic.columnName, testString)
+saveSetting(db, setting.name.columnName, testString)
+saveSetting(db, setting.currentNetwork.columnName, testString)
+saveSetting(db, setting.networks.columnName, testJSON)
+saveSetting(db, setting.nodeConfig.columnName, testJSON)
+saveSetting(db, setting.notificationsEnabled.columnName, testBool)
+saveSetting(db, setting.photoPath.columnName, testString)
+saveSetting(db, setting.pinnedMailservers.columnName, testJSON)
+saveSetting(db, setting.preferredName.columnName, testString)
+saveSetting(db, setting.previewPrivacy.columnName, testBool)
+saveSetting(db, setting.publicKey.columnName, testString)
+saveSetting(db, setting.rememberSyncingChoice.columnName, testBool)
+saveSetting(db, setting.remotePushNotificationsEnabled.columnName, testBool)
+saveSetting(db, setting.pushNotificationsServerEnabled.columnName, testBool)
+saveSetting(db, setting.pushNotificationsFromContactsOnly.columnName, testBool)
+saveSetting(db, setting.sendPushNotifications.columnName, testBool)
+saveSetting(db, setting.stickerPacksInstalled.columnName, testJSON)
+saveSetting(db, setting.stickersPacksPending.columnName, testJSON)
+saveSetting(db, setting.stickersRecentStickers.columnName, testJSON)
+saveSetting(db, setting.syncingOnMobileNetwork.columnName, testBool)
+saveSetting(db, setting.usernames.columnName, testJSON)
+saveSetting(db, setting.walletSetupPassed.columnName, testBool)
+saveSetting(db, setting.walletVisibleTokens.columnName, testJSON)
+saveSetting(db, setting.appearance.columnName, testInt)
+saveSetting(db, setting.wakuEnabled.columnName, testBool)
+saveSetting(db, setting.wakuBloomFilterMode.columnName, testBool)
 
 let dbSettings2 = getSettings(db)
 
@@ -103,8 +109,8 @@ assert dbSettings2.chaosMode.get() == testBool
 assert dbSettings2.currency.get() == testString
 assert dbSettings2.customBootNodes.get() == testJson
 assert dbSettings2.customBootNodesEnabled.get() == testJson
-assert $dbSettings2.dappsAddress == $testAddress
-assert $dbSettings2.eip1581Address == $testAddress
+assert dbSettings2.dappsAddress == testAddress
+assert dbSettings2.eip1581Address == testAddress
 assert dbSettings2.fleet.get() == testString
 assert dbSettings2.hideHomeTooltip.get() == testBool
 assert dbSettings2.keycardInstanceUID.get() == testString
@@ -116,7 +122,7 @@ assert dbSettings2.logLevel.get() == testString
 assert dbSettings2.mnemonic.get() == testString
 assert dbSettings2.name.get() == testString
 assert dbSettings2.currentNetwork == testString
-assert $dbSettings2.networks == $testJSON
+assert dbSettings2.networks == testJSON
 assert dbSettings2.notificationsEnabled.get() == testBool
 assert dbSettings2.photoPath == testString
 assert dbSettings2.pinnedMailservers.get() == testJSON
@@ -128,7 +134,7 @@ assert dbSettings2.remotePushNotificationsEnabled.get() == testBool
 assert dbSettings2.pushNotificationsServerEnabled.get() == testBool
 assert dbSettings2.pushNotificationsFromContactsOnly.get() == testBool
 assert dbSettings2.sendPushNotifications.get() == testBool
-assert $dbSettings2.stickerPacksInstalled.get() == $testJSON
+assert dbSettings2.stickerPacksInstalled.get() == testJSON
 assert dbSettings2.stickersPacksPending.get() == testJSON
 assert dbSettings2.stickersRecentStickers.get() == testJSON
 assert dbSettings2.syncingOnMobileNetwork.get() == testBool
@@ -139,7 +145,7 @@ assert dbSettings2.appearance == testUint
 assert dbSettings2.wakuEnabled.get() == testBool
 assert dbSettings2.wakuBloomFilterMode.get() == testBool
 
-assert $getNodeConfig(db) == $testJSON
+assert getNodeConfig(db) == testJSON
 
 db.close()
 removeFile(path)


### PR DESCRIPTION
Creating this as a draft PR to test (via CI) the possibility of the Windows+shared issue being alleviated with an update to `nim-sqlcipher` to match the latest `tiny_sqlite` APIs.