### PR TITLE
ci: implement workaround re: Rust in MSYS2/MINGW64 on Windows

### DIFF
--- a/.github/workflows/chat.yml
+++ b/.github/workflows/chat.yml
@@ -60,14 +60,11 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          # installing mingw-w64-x86_64-libxml2 is a workaround for:
-          # https://github.com/msys2/MINGW-packages/issues/8658
           install: >
             base-devel
             git
             unzip
             mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-libxml2
             mingw-w64-x86_64-ncurses
             mingw-w64-x86_64-openssl
             mingw-w64-x86_64-pcre
@@ -94,6 +91,8 @@ jobs:
           key: ${{ matrix.platform.os }}-${{ steps.calc-cache-key.outputs.hash }}-release-${{ matrix.release }}
 
       - name: Install and build dependencies
+        # setting env var RUSTFLAGS in Windows is a workaround for:
+        # https://github.com/msys2/MINGW-packages/issues/9010
         run: |
           make \
             -j${NPROC} \
@@ -102,6 +101,9 @@ jobs:
             RLN_STATIC=${{ matrix.rln }} \
             V=1 \
             update
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            export RUSTFLAGS="-Clink-self-contained=no"
+          fi
           make \
             -j${NPROC} \
             NIMFLAGS="--parallelBuild:${NPROC}" \
@@ -114,10 +116,11 @@ jobs:
         run: |
           # workaround for limitations of BSD `ar` on macOS
           # see: https://github.com/nim-lang/Nim/issues/15589
-          (([[ ${{ matrix.platform.os }} = macos ]] && \
-            mkdir -p "${HOME}/.local/bin" && \
-            ln -f -s /usr/local/Cellar/llvm/*/bin/llvm-ar "${HOME}/.local/bin/ar") || true)
-          export PATH="${HOME}/.local/bin:${PATH}"
+          if [[ ${{ matrix.platform.os }} = macos ]]; then
+            mkdir -p "${HOME}/.local/bin"
+            ln -f -s /usr/local/Cellar/llvm/*/bin/llvm-ar "${HOME}/.local/bin/ar"
+            export PATH="${HOME}/.local/bin:${PATH}"
+          fi
           make \
             NCURSES_STATIC=${{ matrix.ncurses }} \
             NIMFLAGS="--parallelBuild:${NPROC}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,14 +53,11 @@ jobs:
         with:
           msystem: MINGW64
           update: true
-          # installing mingw-w64-x86_64-libxml2 is a workaround for:
-          # https://github.com/msys2/MINGW-packages/issues/8658
           install: >
             base-devel
             git
             unzip
             mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-libxml2
             mingw-w64-x86_64-openssl
             mingw-w64-x86_64-pcre
             mingw-w64-x86_64-rust
@@ -86,18 +83,24 @@ jobs:
           key: ${{ matrix.platform.os }}-${{ steps.calc-cache-key.outputs.hash }}-sqlcipher_static-${{ matrix.sqlcipher }}
 
       - name: Install and build dependencies
+        # setting env var RUSTFLAGS in Windows is a workaround for:
+        # https://github.com/msys2/MINGW-packages/issues/9010
         run: |
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
+          if [[ ${{ matrix.platform.os }} = windows ]]; then
+            export RUSTFLAGS="-Clink-self-contained=no"
+          fi
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 deps
 
       - name: Build and run tests
         run: |
           # workaround for limitations of BSD `ar` on macOS
           # see: https://github.com/nim-lang/Nim/issues/15589
-          (([[ ${{ matrix.platform.os }} = macos ]] && \
-            mkdir -p "${HOME}/.local/bin" && \
-            ln -f -s /usr/local/Cellar/llvm/*/bin/llvm-ar "${HOME}/.local/bin/ar") || true)
-          export PATH="${HOME}/.local/bin:${PATH}"
+          if [[ ${{ matrix.platform.os }} = macos ]]; then
+            mkdir -p "${HOME}/.local/bin"
+            ln -f -s /usr/local/Cellar/llvm/*/bin/llvm-ar "${HOME}/.local/bin/ar"
+            export PATH="${HOME}/.local/bin:${PATH}"
+          fi
           make \
             NIMFLAGS="--parallelBuild:${NPROC}" \
             PCRE_STATIC=${{ matrix.pcre }} \


### PR DESCRIPTION
See: https://github.com/msys2/MINGW-packages/issues/9010

Also remove a previous workaround re: Rust in MSYS2/MINGW64 on Windows that's no longer necessary.

And cleanup implementation of a workaround re: the `ar` utility on macOS, i.e. do it the same way using an `if..fi` block.