### PR TITLE
ci: remove workaround re: setting RUSTFLAGS env var in Windows

### DIFF
--- a/.github/workflows/chat.yml
+++ b/.github/workflows/chat.yml
@@ -91,8 +91,6 @@ jobs:
           key: ${{ matrix.platform.os }}-${{ steps.calc-cache-key.outputs.hash }}-release-${{ matrix.release }}
 
       - name: Install and build dependencies
-        # setting env var RUSTFLAGS in Windows is a workaround for:
-        # https://github.com/msys2/MINGW-packages/issues/9010
         run: |
           make \
             -j${NPROC} \
@@ -101,9 +99,6 @@ jobs:
             RLN_STATIC=${{ matrix.rln }} \
             V=1 \
             update
-          if [[ ${{ matrix.platform.os }} = windows ]]; then
-            export RUSTFLAGS="-Clink-self-contained=no"
-          fi
           make \
             -j${NPROC} \
             NIMFLAGS="--parallelBuild:${NPROC}" \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,13 +93,8 @@ jobs:
           key: ${{ matrix.platform.os }}-${{ steps.calc-cache-key.outputs.hash }}-sqlcipher_static-${{ matrix.sqlcipher }}
 
       - name: Install and build dependencies
-        # setting env var RUSTFLAGS in Windows is a workaround for:
-        # https://github.com/msys2/MINGW-packages/issues/9010
         run: |
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 update
-          if [[ ${{ matrix.platform.os }} = windows ]]; then
-            export RUSTFLAGS="-Clink-self-contained=no"
-          fi
           make -j${NPROC} NIMFLAGS="--parallelBuild:${NPROC}" V=1 deps
 
       - name: Build and run tests


### PR DESCRIPTION
It's no longer necessary owing to changes made yesterday by the MSYS2 maintainers/contributors.