### PR TITLE
feat: Add create account and list accounts commands

### DIFF
--- a/examples/chat/client.nim
+++ b/examples/chat/client.nim
@@ -42,11 +42,17 @@ proc stop*(self: ChatClient) {.async.} =
 
   debug "client stopped"
 
+proc listAccounts*(self: ChatClient) {.async.} =
+  asyncSpawn listAccounts(self.taskRunner, status)
+
 proc login*(self: ChatClient, username: string) {.async.} =
   asyncSpawn startWakuChat2(self.taskRunner, status, username)
 
 proc logout*(self: ChatClient) {.async.} =
   asyncSpawn stopWakuChat2(self.taskRunner, status)
+
+proc generateMultiAccount*(self: ChatClient, password: string) {.async.} =
+  asyncSpawn generateMultiAccount(self.taskRunner, status, password)
 
 proc sendMessage*(self: ChatClient, message: string) {.async.} =
   asyncSpawn publishWakuChat2(self.taskRunner, status, message)

--- a/examples/chat/client/events.nim
+++ b/examples/chat/client/events.nim
@@ -1,5 +1,5 @@
 import # chat libs
-  ./common
+  ./common, ../../../nim_status/accounts
 
 export common
 
@@ -8,6 +8,14 @@ logScope:
 
 type
   ClientEvent* = ref object of Event
+
+  CreateAccountResult* = ref object of ClientEvent
+    account*: Account
+    timestamp*: int64
+
+  ListAccountsResult* = ref object of ClientEvent
+    accounts*: seq[Account]
+    timestamp*: int64
 
   NetworkStatus* = ref object of ClientEvent
     online*: bool
@@ -18,6 +26,8 @@ type
     username*: string
 
 const clientEvents* = [
+  "CreateAccountResult",
+  "ListAccountsResult",
   "NetworkStatus",
   "UserMessage"
 ]

--- a/examples/chat/task_runner/tasks.nim
+++ b/examples/chat/task_runner/tasks.nim
@@ -1,7 +1,7 @@
 import # vendor libs
-  chronicles, chronos, json_serialization
+  chronicles, chronos, json_serialization, json_serialization/std/options
 
-export chronicles, json_serialization
+export chronicles, json_serialization, options
 
 logScope:
   topics = "task_runner"

--- a/examples/chat/task_runner/workers/thread_worker.nim
+++ b/examples/chat/task_runner/workers/thread_worker.nim
@@ -94,8 +94,8 @@ proc worker(arg: WorkerThreadArg) {.async.} =
         else:
           asyncSpawn task(message)
 
-      except:
-        error "worker received unknown message", message, worker
+      except Exception as e:
+        error "worker received unknown message", message, worker, error=e.msg
 
   chanRecvFromHost.close()
   chanSendToHost.close()

--- a/examples/chat/tui/commands.nim
+++ b/examples/chat/tui/commands.nim
@@ -37,6 +37,32 @@ proc command*(self: ChatTUI, command: Help) {.async, gcsafe, nimcall.} =
   let command = command.command
   discard
 
+# CreateAccount ----------------------------------------------------------------
+
+proc new*(T: type CreateAccount, args: varargs[string]): T =
+  T(password: args[0])
+
+proc split*(T: type CreateAccount, argsRaw: string): seq[string] =
+  return @[argsRaw]
+
+proc command*(self: ChatTUI, command: CreateAccount) {.async, gcsafe, nimcall.} =
+  if command.password == "":
+    self.wprintFormatError(epochTime().int64,
+      "password cannot be blank, please provide a password as the first argument.")
+  else:
+    asyncSpawn self.client.generateMultiAccount(command.password)
+
+# ListAccounts -----------------------------------------------------------------
+
+proc new*(T: type ListAccounts, args: varargs[string]): T =
+  T()
+
+proc split*(T: type ListAccounts, argsRaw: string): seq[string] =
+  return @[]
+
+proc command*(self: ChatTUI, command: ListAccounts) {.async, gcsafe, nimcall.} =
+  asyncSpawn self.client.listAccounts()
+
 # Login ------------------------------------------------------------------------
 
 proc new*(T: type Login, args: varargs[string]): T {.raises: [].} =

--- a/examples/chat/tui/common.nim
+++ b/examples/chat/tui/common.nim
@@ -43,6 +43,11 @@ type
   Help* = ref object of Command
     command*: string
 
+  CreateAccount* = ref object of Command
+    password*: string
+
+  ListAccounts* = ref object of Command
+
   Login* = ref object of Command
     username*: string
     # password*: string
@@ -66,19 +71,25 @@ const
   commands* = {
     DEFAULT_COMMAND: "SendMessage",
     "help": "Help",
+    "listaccounts": "ListAccounts",
     "login": "Login",
     "logout": "Logout",
-    "quit": "Quit"
+    "quit": "Quit",
+    "createaccount": "CreateAccount"
   }.toTable
 
   aliases* = {
     "?": "help",
+    "create": "createaccount",
+    "list": "listaccounts",
     "send": DEFAULT_COMMAND
   }.toTable
 
   aliased* = {
     DEFAULT_COMMAND: @["send"],
-    "help": @["?"]
+    "createaccount": @["create"],
+    "help": @["?"],
+    "listaccounts": @["list"]
   }.toTable
 
 proc stop*(self: ChatTUI) {.async.} =

--- a/examples/chat/tui/screen.nim
+++ b/examples/chat/tui/screen.nim
@@ -1,5 +1,5 @@
 import # std libs
-  std/strformat
+  std/[strformat, strutils]
 
 import # chat libs
   ./common
@@ -123,6 +123,9 @@ proc drawScreen*(self: ChatTUI, redraw = false) =
   else:
     trace "TUI drew the initial screen"
 
+proc indent*(spaces: int): string =
+  " ".repeat(spaces)
+
 proc initScreen*(): (string, PWindow, bool) =
   # initialize ncurses
   let
@@ -165,6 +168,19 @@ proc printMessage*(self: ChatTUI, message: string, timestamp: int64,
 
   let tstamp = timestamp.fromUnix().local().format("'<'MMM' 'dd,' 'HH:mm'>'")
   wprintw(self.chatWin, tstamp & " " & username & ": " & message & "\n")
+  wrefresh(self.chatWin)
+
+  # move cursor to input window and refresh
+  wcursyncup(self.inputWin)
+  wrefresh(self.inputWin)
+
+  trace "TUI printed in message window"
+
+# replace `printResult` with adaptions of ncurses calls in TBDChat
+proc printResult*(self: ChatTUI, message: string, timestamp: int64) =
+
+  let tstamp = timestamp.fromUnix().local().format("'<'MMM' 'dd,' 'HH:mm'>'")
+  wprintw(self.chatWin, tstamp & ": " & message & "\n")
   wrefresh(self.chatWin)
 
   # move cursor to input window and refresh

--- a/nim_status/account.nim
+++ b/nim_status/account.nim
@@ -10,6 +10,7 @@ import
 export KeySeed, Mnemonic, SecretKeyResult, KeyPath
 
 type Account* = ref object
+  keyUid*: string
   address*: string
   publicKey*: string
   privateKey*: string

--- a/nim_status/client.nim
+++ b/nim_status/client.nim
@@ -25,8 +25,7 @@ type StatusObject* = ref object
 proc new*(T: type StatusObject, dataDir: string,
   accountsDbFileName: string = "accounts.sql"): T =
 
-  T(accountsDB: initializeDB(dataDir / accountsDbFileName,
-      acc_migration.newMigrationDefinition(), true),
+  T(accountsDB: initializeDB(dataDir / accountsDbFileName),
     dataDir: dataDir)
 
 proc getAccounts*(self: StatusObject): seq[accounts.Account] =
@@ -45,7 +44,7 @@ proc getSettings*(self: StatusObject): Settings =
   getSettings(self.userDB)
 
 proc login*(self: StatusObject, keyUid: string, password: string) =
-  self.userDB = initializeDB(self.dataDir / keyUid & ".db", password, app_migration.newMigrationDefinition(), true) # Disabling migrations because we are reusing a status-go DB
+  self.userDB = initializeDB(self.dataDir / keyUid & ".db", password)
   echo "==============================="
   echo "DB path: " & (self.dataDir / keyUid & ".db")
   echo "Password: " & password
@@ -53,13 +52,20 @@ proc login*(self: StatusObject, keyUid: string, password: string) =
   echo "Result: "
   echo $result
 
-proc multiAccountGenerateAndDeriveAddresses*(self: StatusObject, mnemonicPhraseLength: int, n: int, bip39Passphrase: string, paths: seq[string]): seq[MultiAccount] =
-  return generateAndDeriveAddresses(mnemonicPhraseLength, n, bip39Passphrase, paths)
+proc multiAccountGenerateAndDeriveAddresses*(self: StatusObject,
+  mnemonicPhraseLength: int, n: int, bip39Passphrase: string, paths: seq[string]
+  ): seq[MultiAccount] =
 
-proc multiAccountStoreDerivedAccounts*(self: StatusObject, multiAcc: MultiAccount, password: string, dir: string, pathStrings: seq[string] = newSeq[string]()) =
-  storeDerivedAccounts(multiAcc, password, dir, pathStrings)
+  generateAndDeriveAddresses(mnemonicPhraseLength, n, bip39Passphrase, paths)
 
-proc loadAccount*(self: StatusObject, address: string, password: string, dir: string = ""): account.Account =
+proc multiAccountStoreDerivedAccounts*(self: StatusObject,
+  multiAcc: MultiAccount, password: string, dir: string) =
+
+  storeDerivedAccounts(multiAcc, password, dir)
+
+proc loadAccount*(self: StatusObject, address: string, password: string,
+  dir: string = ""): account.Account =
+
   return loadAccount(address, password, dir)
 
 proc closeUserDB*(self: StatusObject) =

--- a/nim_status/database.nim
+++ b/nim_status/database.nim
@@ -1,15 +1,28 @@
 import os, results, sqlcipher
 
-import ./migration
+import
+  ./migration,
+  ./migrations/sql_scripts_accounts as acc_migration,
+  ./migrations/sql_scripts_app as app_migration
 
-proc initializeDB*(path:string, definition: MigrationDefinition, runMigrations = true): DbConn =
+proc initializeDB*(path:string): DbConn =
+
   createDir path.parentDir()
+  var runMigrations = false
+  if not path.fileExists():
+    runMigrations = true
   result = openDatabase(path)
-  if runMigrations and not result.migrate(definition).isOk:
-    raise newException(SqliteError, "Failure executing migrations")
+  if runMigrations:
+    let definition = acc_migration.newMigrationDefinition()
+    if not result.migrate(definition).isOk:
+      raise newException(SqliteError, "Failure executing migrations")
 
-proc initializeDB*(path, password: string, definition: MigrationDefinition, runMigrations = true): DbConn =
+proc initializeDB*(path, password: string): DbConn =
+
   createDir path.parentDir()
+  var runMigrations = false
+  if not path.fileExists():
+    runMigrations = true
   result = openDatabase(path)
   result.key(password)
   result.exec("PRAGMA cipher_page_size = 1024")
@@ -18,5 +31,7 @@ proc initializeDB*(path, password: string, definition: MigrationDefinition, runM
   result.exec("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1")
   result.exec("PRAGMA foreign_keys = ON")
   result.exec("PRAGMA journal_mode = WAL")
-  if runMigrations and not result.migrate(definition).isOk:
-    raise newException(SqliteError, "Failure executing migrations")
+  if runMigrations:
+    let definition = app_migration.newMigrationDefinition()
+    if not result.migrate(definition).isOk:
+      raise newException(SqliteError, "Failure executing migrations")

--- a/nim_status/mnemonic.nim
+++ b/nim_status/mnemonic.nim
@@ -6,9 +6,6 @@ import stew/bitseqs
 import nimcrypto/sysrand as sysrand
 import nimcrypto/sha2 as sha2
 
-const words = staticRead("wordlists/english.txt")
-let wordSeq = words.split("\n")
-
 type 
   EntropyStrength = distinct uint
   BitSeq = seq[byte]
@@ -70,6 +67,9 @@ proc mnemonicPhrase*(strength: int, language: Language): string =
   let checksum = getBits($hash)
 
   entropyBits = concat(entropyBits, checksum[0..3])
+
+  const wordlist = staticRead("wordlists/english.txt")
+  let wordSeq = wordlist.split("\n")
 
   let wordBitSeq = entropyBits.distribute(12)
   var words = newSeq[string]()

--- a/nim_status/util.nim
+++ b/nim_status/util.nim
@@ -1,14 +1,16 @@
 import nimcrypto, re, strutils, unicode, web3/ethtypes
 
-let reHex = re("^[0-9a-f]+$", {reIgnoreCase})
+const hexPattern = "^[0-9a-f]+$"
 
 proc isHexString*(str: string): bool =
+  let reHex = re(hexPattern, {reIgnoreCase})
   str.len > 3 and
   str.len mod 2 == 0 and
   str[0..1] == "0x" and
   match(str[2..^1], reHex)
 
 proc isPubKey*(str: string): bool =
+  let reHex = re(hexPattern, {reIgnoreCase})
   str.len == 132 and
   str[0..3] == "0x04" and
   match(str[2..^1], reHex)

--- a/test/callrpc.nim
+++ b/test/callrpc.nim
@@ -15,7 +15,7 @@ procSuite "callrpc":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let settingsStr = """{
       "address": "0x1122334455667788990011223344556677889900",

--- a/test/chats.nim
+++ b/test/chats.nim
@@ -14,7 +14,7 @@ procSuite "chats":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     var chat = Chat(
       id: "ContactId",

--- a/test/client.nim
+++ b/test/client.nim
@@ -17,7 +17,7 @@ procSuite "client":
 
     var account:Account = Account(
       name: "Test",
-      loginTimestamp: 1,
+      loginTimestamp: 1.some,
       identicon: "data:image/png;base64,something",
       keycardPairing: "",
       keyUid: "0x1234"

--- a/test/contacts.nim
+++ b/test/contacts.nim
@@ -15,7 +15,7 @@ procSuite "contacts":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let contact1 = Contact(
       id: "Contact1",

--- a/test/mailservers.nim
+++ b/test/mailservers.nim
@@ -14,7 +14,7 @@ procSuite "mailservers":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let mailserver1 = Mailserver(
       id: "mailserver-1",

--- a/test/messages.nim
+++ b/test/messages.nim
@@ -14,7 +14,7 @@ procSuite "messages":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     var msg = Message(
       id: "msg1",

--- a/test/multiaccount.nim
+++ b/test/multiaccount.nim
@@ -1,15 +1,12 @@
 import # nim libs
-  os, strutils, unittest
+  os, unittest
 
 import # vednor libs
   chronos, eth/[keys, p2p]
 
-
 import # nim-status libs
-  ../nim_status/account,
-  ../nim_status/mnemonic,
-  ../nim_status/multiaccount,
-  ./test_helpers
+  ../nim_status/[account, multiaccount], ./test_helpers
+
 
 procSuite "multiaccount":
   test "multiaccount":
@@ -17,7 +14,7 @@ procSuite "multiaccount":
     assert entropyStrength == 128
 
     let passphrase = ""
-    let multiAccounts = generateAndDeriveAddresses(12, 1, passphrase, @["m/44'/60'/0'/0", "m/44'/60'/0'/0/0", "m/43'/60'/1581'/0'/0"])
+    let multiAccounts = generateAndDeriveAddresses(12, 1, passphrase, @[PATH_WALLET_ROOT, PATH_DEFAULT_WALLET, PATH_WHISPER])
 
     #assert len(multiAccounts) == 5
 

--- a/test/pendingtxs.nim
+++ b/test/pendingtxs.nim
@@ -14,7 +14,7 @@ procSuite "pendingtxs":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let tx = PendingTx(
       networkId: 1,

--- a/test/permissions.nim
+++ b/test/permissions.nim
@@ -14,7 +14,7 @@ procSuite "permissions":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let dappPerm1: DappPermissions = DappPermissions(
       name: "Dapp1",

--- a/test/settings.nim
+++ b/test/settings.nim
@@ -15,7 +15,7 @@ procSuite "settings":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let settingsStr = """{
       "address": "0x1122334455667788990011223344556677889900",

--- a/test/tokens.nim
+++ b/test/tokens.nim
@@ -14,7 +14,7 @@ procSuite "tokens":
     let password = "qwerty"
     let path = currentSourcePath.parentDir() & "/build/my.db"
     removeFile(path)
-    let db = initializeDB(path, password, newMigrationDefinition())
+    let db = initializeDB(path, password)
 
     let tokensStr = """{
       "address": "0x1122334455667788990011223344556677889900",

--- a/test/tx_history.nim
+++ b/test/tx_history.nim
@@ -17,7 +17,7 @@ import ../../nim_status/tx_history/types
 # Initialize db
 let passwd = "qwerty"
 let path = currentSourcePath.parentDir() & "/build/myDatabase"
-let db = initializeDB(path, passwd, newMigrationDefinition())
+let db = initializeDB(path, passwd)
 
 #f315575765b14720b32382a61a89341a # real infura project id
 #40ec14d9d9384d52b7fbcfecdde4e2c0 # test infura project id


### PR DESCRIPTION
Closes: #180.
Closes: #177.
Closes: #184.

Accounts can be created with the `/create` or `/createaccount` command. Existing accounts can be listed with the `/list` or `/listaccounts` command.

Account keyuid is now being generated on the multiaccount.

account.loginTimestamp is now NULL when inserted in the DB, and can be updated using `updateAccount` or `updateAccountTimestamp`.

fix: run migrations only on non-existant DBs
Removes the need to pass in a migration definition file. We do not need to run migrations, unless we are instantiating a DB.