### PR TITLE
feat: Add help command and help definitions

### DIFF
--- a/examples/chat/client.nim
+++ b/examples/chat/client.nim
@@ -48,6 +48,9 @@ proc connect*(self: ChatClient, username: string) {.async.} =
 proc disconnect*(self: ChatClient) {.async.} =
   asyncSpawn stopWakuChat2(self.taskRunner, status)
 
+proc generateMultiAccount*(self: ChatClient, password: string) {.async.} =
+  asyncSpawn generateMultiAccount(self.taskRunner, status, password)
+
 proc listAccounts*(self: ChatClient) {.async.} =
   asyncSpawn listAccounts(self.taskRunner, status)
 
@@ -56,9 +59,6 @@ proc login*(self: ChatClient, account: int, password: string) {.async.} =
 
 proc logout*(self: ChatClient) {.async.} =
   asyncSpawn logout(self.taskRunner, status)
-
-proc generateMultiAccount*(self: ChatClient, password: string) {.async.} =
-  asyncSpawn generateMultiAccount(self.taskRunner, status, password)
 
 proc importMnemonic*(self: ChatClient, mnemonic: string, passphrase: string,
   password: string) {.async.} =

--- a/examples/chat/client/common.nim
+++ b/examples/chat/client/common.nim
@@ -17,6 +17,8 @@ type
 
   EventChannel* = AsyncChannel[ThreadSafeString]
 
+  # TODO: alphabetise ChatClient above HelpText -- didn't want to interfere
+  # with ongoing work
   ChatClient* = ref object
     account*: Account
     chatConfig*: ChatConfig

--- a/examples/chat/tui/actions.nim
+++ b/examples/chat/tui/actions.nim
@@ -1,5 +1,5 @@
 import # std libs
-  std/strformat
+  std/[strformat, strutils]
 
 import # nim-status libs
   ../../../nim_status/[accounts, alias, multiaccount]

--- a/examples/chat/tui/commands.nim
+++ b/examples/chat/tui/commands.nim
@@ -1,10 +1,10 @@
 import # std libs
-  std/strutils
+  std/[sequtils, strformat, strutils, sugar]
 
 import # chat libs
-  ./screen, ./tasks
+  ./common, ./macros, ./screen, ./tasks
 
-export screen, strutils, tasks
+export common, screen, strutils, tasks
 
 logScope:
   topics = "chat tui"
@@ -27,6 +27,10 @@ logScope:
 
 # Connect ----------------------------------------------------------------------
 
+proc help*(T: type Connect): HelpText =
+  let command = "connect"
+  HelpText(command: command, description: "Connects to the waku network.")
+
 proc new*(T: type Connect, args: varargs[string]): T {.raises: [].} =
   T()
 
@@ -41,6 +45,13 @@ proc command*(self: ChatTUI, command: Connect) {.async, gcsafe, nimcall.} =
       "client is not logged in, cannot connect.")
 
 # CreateAccount ----------------------------------------------------------------
+
+proc help*(T: type CreateAccount): HelpText =
+  let command = "createaccount"
+  HelpText(command: command, aliases: aliased[command], parameters: @[
+    CommandParameter(name: "password", description: "Password for the new " &
+      "account.")
+    ], description: "Creates a new Status account.")
 
 proc new*(T: type CreateAccount, args: varargs[string]): T =
   T(password: args[0])
@@ -59,6 +70,10 @@ proc command*(self: ChatTUI, command: CreateAccount) {.async, gcsafe,
 
 # Disconnect -------------------------------------------------------------------
 
+proc help*(T: type Disconnect): HelpText =
+  let command = "disconnect"
+  HelpText(command: command, description: "Disconnects from the waku network.")
+
 proc new*(T: type Disconnect, args: varargs[string]): T =
   T()
 
@@ -71,19 +86,19 @@ proc command*(self: ChatTUI, command: Disconnect) {.async, gcsafe, nimcall.} =
   else:
     self.wprintFormatError(epochTime().int64, "client is not online.")
 
-# Help -------------------------------------------------------------------------
-
-proc new*(T: type Help, args: varargs[string]): T =
-  T(command: args[0])
-
-proc split*(T: type Help, argsRaw: string): seq[string] =
-  @[argsRaw.split(" ")[0]]
-
-proc command*(self: ChatTUI, command: Help) {.async, gcsafe, nimcall.} =
-  let command = command.command
-  discard
 
 # ImportMnemonic -----------------------------------------------------------------
+
+proc help*(T: type ImportMnemonic): HelpText =
+  let command = "importmnemonic"
+  HelpText(command: command, aliases: aliased[command], parameters: @[
+    CommandParameter(name: "mnemonic", description: "The mnemonic seed " &
+      "phrase used to import the account."),
+    CommandParameter(name: "passphrase", description: "(Optional) The " &
+      "passphrase used for securing against seed loss/theft."),
+    CommandParameter(name: "password", description: "The password used to " &
+      "encrypt the keystore file.")
+    ], description: "Imports a Status account from a mnemoic.")
 
 proc new*(T: type ImportMnemonic, args: varargs[string]): T =
   T(mnemonic: args[0], passphrase: args[1], password: args[2])
@@ -130,6 +145,11 @@ proc command*(self: ChatTUI, command: ImportMnemonic) {.async, gcsafe, nimcall.}
 
 # ListAccounts -----------------------------------------------------------------
 
+proc help*(T: type ListAccounts): HelpText =
+  let command = "listaccounts"
+  HelpText(command: command, aliases: aliased[command], description: "Lists " &
+    "all existing Status accounts.")
+
 proc new*(T: type ListAccounts, args: varargs[string]): T =
   T()
 
@@ -140,6 +160,14 @@ proc command*(self: ChatTUI, command: ListAccounts) {.async, gcsafe, nimcall.} =
   asyncSpawn self.client.listAccounts()
 
 # Login ------------------------------------------------------------------------
+
+proc help*(T: type Login): HelpText =
+  let command = "login"
+  HelpText(command: command, parameters: @[
+    CommandParameter(name: "index", description: "Index of existing account, " &
+      "which can be retrieved using the `/list` command."),
+    CommandParameter(name: "password", description: "Account password.")
+    ], description: "Logs in to the Status account.")
 
 proc new*(T: type Login, args: varargs[string]): T {.raises: [].} =
   T(account: args[0], password: args[1])
@@ -175,6 +203,11 @@ proc command*(self: ChatTUI, command: Login) {.async, gcsafe, nimcall.} =
 
 # Logout -----------------------------------------------------------------------
 
+proc help*(T: type Logout): HelpText =
+  let command = "logout"
+  HelpText(command: command, description: "Logs out of the currently logged " &
+    "in Status account.")
+
 proc new*(T: type Logout, args: varargs[string]): T =
   T()
 
@@ -186,6 +219,10 @@ proc command*(self: ChatTUI, command: Logout) {.async, gcsafe, nimcall.} =
 
 # Quit -------------------------------------------------------------------------
 
+proc help*(T: type Quit): HelpText =
+  let command = "quit"
+  HelpText(command: command, description: "Quits the chat client.")
+
 proc new*(T: type Quit, args: varargs[string]): T =
   T()
 
@@ -196,6 +233,16 @@ proc command*(self: ChatTUI, command: Quit) {.async, gcsafe, nimcall.} =
   await self.stop()
 
 # SendMessage ------------------------------------------------------------------
+
+proc help*(T: type SendMessage): HelpText =
+  let command = ""
+  HelpText(command: command, aliases: aliased[command], parameters: @[
+    CommandParameter(name: "message", description: "Message to send on the " &
+      "network. Max length ???")
+    ], description: "Sends a message on the waku network. By default, no " &
+    "command is needed. Text entered that is not preceded by a command will " &
+    "be interpreted as a send command, ie typing `hello` will be interpreted " &
+    "as `/send hello`.")
 
 proc new*(T: type SendMessage, args: varargs[string]): T =
   T(message: args[0])
@@ -209,3 +256,125 @@ proc command*(self: ChatTUI, command: SendMessage) {.async, gcsafe, nimcall.} =
       "client is not online, cannot send message.")
   else:
     asyncSpawn self.client.sendMessage(command.message)
+
+# Help -------------------------------------------------------------------------
+# Note: although "Help" is not alphabetically last, we need to keep this below
+# all other `help()` definitions so that they are available to the
+# `buildCommandHelp()` macro. Alternatively, we could use forward declarations
+# at the top of the file, but this introduces an additional update for a
+# developer implementing a new command.
+
+proc help*(T: type Help): HelpText =
+  let command = "help"
+  HelpText(command: command, aliases: aliased[command], parameters: @[
+    CommandParameter(name: "command", description: "(Optional) Command to " &
+      "get help for. If omitted, help for all commands will be displayed.")
+    ], description:
+    "Show help text.")
+
+proc new*(T: type Help, args: varargs[string]): T =
+  T(command: args[0])
+
+proc split*(T: type Help, argsRaw: string): seq[string] =
+  let split = argsRaw.split(" ")
+  result = @[]
+
+  if split.len > 0:
+    var command = split[0]
+    # strip leading "/" if user typed it, ie /help /login => /help login
+    if command.startsWith("/"): command = command.strip(chars = {'/'},
+      leading = true, trailing = false)
+    result.add command
+
+proc command*(self: ChatTUI, command: Help) {.async, gcsafe, nimcall.} =
+  let
+    command = command.command
+    timestamp = epochTime().int64
+  
+  trace "executing help", command
+
+  var helpTexts = buildCommandHelp()
+
+  if command != "":
+    helpTexts = helpTexts.filter(help => help.command == command or help.aliases.contains(command))
+  
+  # display on screen
+  trace "TUI showing cli help", helpTexts=(%helpTexts)
+
+  proc forDisplay(help: HelpText): (string, string) =
+    let
+      command = help.command
+      hasAliases = help.aliases.len > 0
+      aliasPrefix = if hasAliases: ", /" else: ""
+      aliases = aliasPrefix & help.aliases.join(", /")
+    (command, aliases)
+
+  proc commandLength(help: HelpText): int =
+    let (command, aliases) = help.forDisplay
+    result = command.len + aliases.len
+
+  proc longest(helps: seq[HelpText]): int =
+    result = 0
+    for help in helps:
+      let length = help.commandLength
+      if length > result:
+        result = length
+
+  proc longest(params: seq[CommandParameter]): int =
+    result = 0
+    for param in params:
+      let length = param.name.len
+      if length > result:
+        result = length
+
+  if self.outputReady:
+    var introMsg = ""
+    if command != "" and helpTexts.len == 0:
+      introMsg = fmt"Command /{command} is invalid"
+      self.wprintFormatError(timestamp, introMsg)
+      return
+    if command == "":
+      introMsg = "Available commands:"
+    else:
+      introMsg = fmt"Help for /{command}:"
+    self.printResult(introMsg, timestamp)
+    self.printResult("=".repeat(introMsg.len), timestamp)
+    self.printResult("", timestamp) # print blank line
+
+    let
+      spacing = 2
+      totalSpace = helpTexts.longest + spacing
+
+    for helpText in helpTexts:
+      let
+        (command, aliases) = helpText.forDisplay
+        desc = helpText.description
+        spaces = totalSpace - helpText.commandLength
+        paramsJoined = helpText.parameters.map(p => p.name).join("> <")
+        hasParams = helpText.parameters.len > 0
+        paramsList = if hasParams: fmt" <{paramsJoined}>" else: ""
+        finalText = fmt"{spacing.indent()}/{command}{aliases}{paramsList}"
+
+      self.printResult(finalText.replace("/, ", ""), timestamp)
+      self.printResult(fmt"{(spacing * 2).indent}{desc}", timestamp)
+      
+      let
+        params = helpText.parameters
+        totalParamSpace = params.longest + spacing
+
+      if params.len > 0:
+        self.printResult(fmt"{(spacing * 2).indent}Parameters:", timestamp)
+
+      for param in params:
+        let
+          name = param.name
+          paramSpaces = totalParamSpace - name.len
+          desc = param.description
+        self.printResult(
+          fmt"{(spacing * 3).indent()}<{name}>{paramSpaces.indent}{desc}", timestamp)
+
+      # print a blank line
+      self.printResult("", timestamp)
+
+  trace "Sending help texts to the client", help=(%helpTexts)
+

--- a/examples/chat/tui/common.nim
+++ b/examples/chat/tui/common.nim
@@ -43,6 +43,10 @@ type
 
   Connect* = ref object of Command
 
+  CommandParameter* = ref object of RootObj
+    name*: string
+    description*: string
+
   CreateAccount* = ref object of Command
     password*: string
 
@@ -50,6 +54,12 @@ type
 
   Help* = ref object of Command
     command*: string
+
+  HelpText* = ref object of RootObj
+    command*: string
+    parameters*: seq[CommandParameter]
+    aliases*: seq[string]
+    description*: string
 
   ImportMnemonic* = ref object of Command
     mnemonic*: string
@@ -84,8 +94,8 @@ const
     "createaccount": "CreateAccount",
     "disconnect": "Disconnect",
     "help": "Help",
-    "listaccounts": "ListAccounts",
     "importmnemonic": "ImportMnemonic",
+    "listaccounts": "ListAccounts",
     "login": "Login",
     "logout": "Logout",
     "quit": "Quit"

--- a/examples/chat/tui/macros.nim
+++ b/examples/chat/tui/macros.nim
@@ -2,7 +2,7 @@ import # std libs
   std/macros
 
 import # chat libs
-  ./common
+  ./common, ../client/common as client_common
 
 export common
 
@@ -103,3 +103,18 @@ macro commandSplitCases*(): untyped =
     casenode.add(ofbranch)
 
   result.add(casenode)
+
+macro buildCommandHelp*(): untyped =
+  result = newStmtList()
+
+  let helpId = ident("_help_")
+  result.add quote do:
+    var `helpId`: seq[HelpText] = @[]
+
+  for command in commands:
+    let
+      commandType = ident(command)
+    result.add(quote do: `helpId`.add(`commandType`.help()))
+
+  result.add quote do: 
+    `helpId`


### PR DESCRIPTION
Closes #189.

![imgur](https://imgur.com/vQx9DL5.png)

Add support for the `/help` command, which dynamically builds a list of help commands based on the `help()` procs defined for each command type, ie `Login`.

The `help` proc returns a type of `HelpText`, which contains all the information necessary to render help information for that command. It contains the command, parameters (each parameters contains a name and description), aliases, and a description.

The help text is generated (at compile time) by a macro called `buildCommandHelp()`. Once the `/help` command is executed, the output of `buildCommandHelp()` is passed to the task runner so that a `HelpResult` event can be created and the help text can be displayed on screen. Because the text is generated at compile time, it is not necessary to pass this text through the task runner, and is displayed directly on screen in the main thread.

## NOTES
1. The help text is quite long, especially given there are blank spaces in between each command. This would require the chat client to be able to scroll unless it is sufficiently tall.
2. I am not married to the display output at all, even after experimenting with a few different layouts. There is some leftover rendering code in the `HelpResult` action which allows for the the command description to be written on the same line as the command name and keep the description spaced in line with all other descriptions, but it didn’t appear as readable as the format that I settled on in the end. I left it in there in case we wanted to change up how help is rendered.
3. ~~I didn't want to spend too much time on the "blank" part of the `/, /send` command. I figured if there were strong objections to overall layout/rendering, then that may change anyway. But it's definitely possible to remove or change.~~ The `/, /send` has been replaced with `/send` (visible in the first command shown in the screenshot above).
4. Keeping this as a draft for now for two reasons:
  - the base branch (login/logout) is not complete yet
  - the PR can serve as a place to get any feedback on the result