### PR TITLE
refactor: remove unnecessary use of cast in modules within examples

### DIFF
--- a/examples/chat/client/tasks.nim
+++ b/examples/chat/client/tasks.nim
@@ -81,7 +81,7 @@ proc new(T: type UserMessage, wakuMessage: WakuMessage): T =
 
 proc generateMultiAccount*(password: string) {.task(kind=no_rts, stoppable=false).} =
   let
-    paths = cast[seq[KeyPath]](@[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET])
+    paths = @[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET]
     multiAccounts = status.multiAccountGenerateAndDeriveAccounts(12, 1, password,
       paths)
     multiAccount = multiAccounts[0]
@@ -113,7 +113,7 @@ proc generateMultiAccount*(password: string) {.task(kind=no_rts, stoppable=false
 
 proc importMnemonic*(mnemonic: string, passphrase: string, password: string) {.task(kind=no_rts, stoppable=false).} =
   let
-    paths = cast[seq[KeyPath]](@[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET])
+    paths = @[PATH_WALLET_ROOT, PATH_EIP_1581, PATH_WHISPER, PATH_DEFAULT_WALLET]
     multiAccount = importMnemonicAndDeriveAccounts(Mnemonic mnemonic, passphrase, paths)
     dir = status.dataDir / "keystore"
 
@@ -231,8 +231,7 @@ proc startWakuChat2*(username: string) {.task(kind=no_rts, stoppable=false).} =
         let error = decoded.error
         error "received invalid WakuMessage", error
 
-    let topic = cast[waku_chat2.Topic](waku_chat2.DefaultTopic)
-    wakuNode.subscribe(topic, handler)
+    wakuNode.subscribe(DefaultTopic, handler)
 
     subscribed = true
 
@@ -271,4 +270,4 @@ proc publishWakuChat2*(message: string) {.task(kind=no_rts, stoppable=false).} =
     wakuMessage = WakuMessage(payload: chat2pb.buffer,
       contentTopic: contentTopic, version: 0)
 
-  asyncSpawn wakuNode.publish(waku_chat2.DefaultTopic, wakuMessage)
+  asyncSpawn wakuNode.publish(DefaultTopic, wakuMessage)

--- a/examples/chat/tui/tasks.nim
+++ b/examples/chat/tui/tasks.nim
@@ -1,3 +1,6 @@
+import # vendor libs
+  stew/byteutils
+
 import # chat libs
   ./common
 
@@ -66,7 +69,7 @@ proc readInput*() {.task(kind=no_rts, stoppable=false).} =
         bytes.add input.byte
 
         if bytes.len == expected:
-          let event = InputString(str: cast[string](bytes))
+          let event = InputString(str: string.fromBytes(bytes))
           eventEnc = event.encode
           shouldSend = true
           bytes = @[]

--- a/nim_status/multiaccount.nim
+++ b/nim_status/multiaccount.nim
@@ -11,13 +11,13 @@ import # nim-status libs
 
 
 const
-    PATH_WALLET_ROOT* = "m/44'/60'/0'/0"
-    PATH_EIP_1581* = "m/43'/60'/1581'"
+    PATH_WALLET_ROOT* = KeyPath("m/44'/60'/0'/0")
+    PATH_EIP_1581* = KeyPath("m/43'/60'/1581'")
       # EIP1581 Root Key, the extended key from which any whisper key/encryption
       # key can be derived
-    PATH_DEFAULT_WALLET* = PATH_WALLET_ROOT & "/0"
+    PATH_DEFAULT_WALLET* = KeyPath(PATH_WALLET_ROOT.string & "/0")
       # BIP44-0 Wallet key, the default wallet key
-    PATH_WHISPER* = PATH_EIP_1581 & "/0'/0"
+    PATH_WHISPER* = KeyPath(PATH_EIP_1581.string & "/0'/0")
       # EIP1581 Chat Key 0, the default whisper key
     MIN_SEED_BYTES = 16 # 128 bits
       # MinSeedBytes is the minimum number of bytes allowed for a seed to a master node.

--- a/test/chats.nim
+++ b/test/chats.nim
@@ -2,7 +2,8 @@ import # nim libs
   json, options, os, unittest
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher, web3/conversions as web3_conversions
+  chronos, json_serialization, sqlcipher, stew/byteutils,
+  web3/conversions as web3_conversions
 
 import # nim-status libs
   ../nim_status/[chats, contacts, conversions, database, messages],
@@ -24,12 +25,12 @@ procSuite "chats":
       active: true,
       timestamp: 25,
       deletedAtClockValue: 15,
-      publicKey: cast[seq[byte]]("public-key"),
+      publicKey: "public-key".toBytes(),
       unviewedMessageCount: 3,
       lastClockValue: 18,
-      lastMessage: some(cast[seq[byte]]("lastMessage")),
-      members: cast[seq[byte]]("members"),
-      membershipUpdates: cast[seq[byte]]("membershipUpdates"),
+      lastMessage: some("lastMessage".toBytes()),
+      members: "members".toBytes(),
+      membershipUpdates: "membershipUpdates".toBytes(),
       profile: "profile",
       invitationAdmin: "invitationAdmin",
       muted: false,
@@ -51,7 +52,7 @@ procSuite "chats":
 
     check:
       dbChat.active == true and
-        dbChat.publicKey == cast[seq[byte]]("public-key") and
+        dbChat.publicKey == "public-key".toBytes() and
         dbChat.unviewedMessageCount == 3
 
     # [mute/unmute]Chat
@@ -91,7 +92,7 @@ procSuite "chats":
       id: "msg1",
       whisperTimestamp: 0,
       source: "ContactId",
-      destination: cast[seq[byte]]("default_destination"),
+      destination: "default_destination".toBytes(),
       text: "text",
       contentType: 0,
       username: "user1",
@@ -104,8 +105,8 @@ procSuite "chats":
       clockValue: 0,
       seen: false,
       outgoingStatus: "Delivered",
-      parsedText: cast[seq[byte]]("parsed"),
-      rawPayload: cast[seq[byte]]("raw"),
+      parsedText: "parsed".toBytes(),
+      rawPayload: "raw".toBytes(),
       stickerPack: 0,
       stickerHash: "hash",
       commandId: "command1",
@@ -114,9 +115,9 @@ procSuite "chats":
       commandFrom: "commandFrom",
       commandContract: "commandContract",
       commandTransactionHash: "commandTransactionHash",
-      commandSignature: cast[seq[byte]]("commandSignature"),
+      commandSignature: "commandSignature".toBytes(),
       commandState: 3,
-      audioPayload: cast[seq[byte]]("audioPayload"),
+      audioPayload: "audioPayload".toBytes(),
       audioType: 0,
       audioDurationMs: 10,
       audioBase64: "sdf",
@@ -125,7 +126,7 @@ procSuite "chats":
       lineCount: 5,
       links: "links",
       mentions: "mentions",
-      imagePayload: cast[seq[byte]]("blob"),
+      imagePayload: "blob".toBytes(),
       imageType: "type",
       imageBase64: "sdfsdfsdf"
     )

--- a/test/messages.nim
+++ b/test/messages.nim
@@ -2,7 +2,8 @@ import # nim libs
   json, options, os, unittest
 
 import # vendor libs
-  json_serialization, sqlcipher, web3/conversions as web3_conversions
+  json_serialization, sqlcipher, stew/byteutils,
+  web3/conversions as web3_conversions
 
 import # nim-status libs
   ../nim_status/[conversions, chats, database, messages],
@@ -20,7 +21,7 @@ procSuite "messages":
       id: "msg1",
       whisperTimestamp: 0,
       source: "ContactId",
-      destination: cast[seq[byte]]("default_destination"),
+      destination: "default_destination".toBytes(),
       text: "text",
       contentType: 0,
       username: "user1",
@@ -33,8 +34,8 @@ procSuite "messages":
       clockValue: 0,
       seen: false,
       outgoingStatus: "Delivered",
-      parsedText: cast[seq[byte]]("parsed"),
-      rawPayload: cast[seq[byte]]("raw"),
+      parsedText: "parsed".toBytes(),
+      rawPayload: "raw".toBytes(),
       stickerPack: 0,
       stickerHash: "hash",
       commandId: "command1",
@@ -43,9 +44,9 @@ procSuite "messages":
       commandFrom: "commandFrom",
       commandContract: "commandContract",
       commandTransactionHash: "commandTransactionHash",
-      commandSignature: cast[seq[byte]]("commandSignature"),
+      commandSignature: "commandSignature".toBytes(),
       commandState: 3,
-      audioPayload: cast[seq[byte]]("audioPayload"),
+      audioPayload: "audioPayload".toBytes(),
       audioType: 0,
       audioDurationMs: 10,
       audioBase64: "sdf",
@@ -54,7 +55,7 @@ procSuite "messages":
       lineCount: 5,
       links: "links",
       mentions: "mentions",
-      imagePayload: cast[seq[byte]]("blob"),
+      imagePayload: "blob".toBytes(),
       imageType: "type",
       imageBase64: "sdfsdfsdf"
     )
@@ -89,12 +90,12 @@ procSuite "messages":
       active: true,
       timestamp: 25,
       deletedAtClockValue: 15,
-      publicKey: cast[seq[byte]]("public-key"),
+      publicKey: "public-key".toBytes(),
       unviewedMessageCount: 3,
       lastClockValue: 18,
-      lastMessage: some(cast[seq[byte]]("lastMessage")),
-      members: cast[seq[byte]]("members"),
-      membershipUpdates: cast[seq[byte]]("membershipUpdates"),
+      lastMessage: some("lastMessage".toBytes()),
+      members: "members".toBytes(),
+      membershipUpdates: "membershipUpdates".toBytes(),
       profile: "profile",
       invitationAdmin: "invitationAdmin",
       muted: false,

--- a/test/mnemonic.nim
+++ b/test/mnemonic.nim
@@ -11,7 +11,7 @@ import # nim-status libs
 
 procSuite "mnemonic":
   test "mnemonic":
-    let b: byte = cast[byte]('d')
+    let b = 'd'.byte
     let s = getBits b
 
     echo "BitSeq: ", s

--- a/test/multiaccount.nim
+++ b/test/multiaccount.nim
@@ -2,7 +2,7 @@ import # nim libs
   os, unittest
 
 import # vednor libs
-  chronos, eth/[keys, p2p]
+  chronos, eth/[keys, p2p], stew/byteutils
 
 import # nim-status libs
   ../nim_status/[account, multiaccount], ./test_helpers
@@ -14,7 +14,8 @@ procSuite "multiaccount":
     assert entropyStrength == 128
 
     let passphrase = ""
-    let multiAccounts = generateAndDeriveAccounts(12, 1, passphrase, cast[seq[KeyPath]](@[PATH_WALLET_ROOT, PATH_DEFAULT_WALLET, PATH_WHISPER]))
+    let multiAccounts = generateAndDeriveAccounts(12, 1, passphrase,
+      @[PATH_WALLET_ROOT, PATH_DEFAULT_WALLET, PATH_WHISPER])
 
     #assert len(multiAccounts) == 5
 
@@ -23,12 +24,15 @@ procSuite "multiaccount":
 
     let password = "qwerty"
     let dir = "test_accounts"
-    echo "MultiAcc mnemonic: ", cast[string](multiAcc.mnemonic)
+    echo "MultiAcc mnemonic: ", multiAcc.mnemonic.string
 
     let importedMultiAcc = importMnemonic(multiAcc.mnemonic, passphrase)
 
-    assert cast[string](importedMultiAcc.keyseed) == cast[string](multiAcc.keyseed)
-    echo "MultiAcc keyseed: ", cast[string](multiAcc.keyseed)
+    assert string.fromBytes(openArray[byte](importedMultiAcc.keyseed)) ==
+      string.fromBytes(openArray[byte](multiAcc.keyseed))
+
+    echo "MultiAcc keyseed: ", string.fromBytes(openArray[byte](
+      multiAcc.keyseed))
 
     createDir(dir)
 

--- a/test/waku_smoke.nim
+++ b/test/waku_smoke.nim
@@ -2,7 +2,7 @@ import # nim libs
   unittest
 
 import # vendor libs
-  chronicles, chronos, confutils, stew/results,
+  chronicles, chronos, confutils, stew/[byteutils, results],
   waku/v2/node/[config, wakunode2], waku/v2/protocol/waku_message
 
 import # nim-status libs
@@ -18,11 +18,11 @@ procSuite "waku_smoke":
     let
       futures = [newFuture[int](), newFuture[int]()]
       cTopic = "test"
-      message1 = WakuMessage(payload: cast[seq[byte]]("hello"),
+      message1 = WakuMessage(payload: "hello".toBytes(),
         contentTopic: ContentTopic(cTopic))
-      message2 = WakuMessage(payload: cast[seq[byte]]("world"),
+      message2 = WakuMessage(payload: "world".toBytes(),
         contentTopic: ContentTopic(cTopic))
-      done = WakuMessage(payload: cast[seq[byte]]("test done"),
+      done = WakuMessage(payload: "test done".toBytes(),
         contentTopic: ContentTopic(cTopic))
       timeout = 5.minutes
       topic = "testing"
@@ -34,7 +34,7 @@ procSuite "waku_smoke":
     proc handler(topic: Topic, data: seq[byte]) {.async.} =
       let
         message = WakuMessage.init(data).value
-        payload = cast[string](message.payload)
+        payload = string.fromBytes(message.payload)
       info "message received", topic=topic, payload=payload,
         contentTopic=message.contentTopic
       if payload == "hello":


### PR DESCRIPTION
A few uses remain:

* In `examples/waku_chat2.nim`; that code was copied from nim-waku and is only for reference.
* In `chat/client/tasks.nim`, where the signature of `proc statusContext*(arg: ContextArg)` is intended to match `type Context` of `examples/chat/task_runner/tasks.nim` but we know the argument passed to it is actually of `type StatusArg`.
* In multiple modules within `examples/chat/task_runner/`, where casting plays a role in de/serializing data sent across instances of `AsyncChannel`, and resolving the correct type of worker (thread or pool) per `kind` metatdata tracked as part of worker creation.