### PR TITLE
build: switch from MSYS2 MINGW64 to MSYS2 UCRT64

### DIFF
--- a/.github/workflows/chat.yml
+++ b/.github/workflows/chat.yml
@@ -55,20 +55,21 @@ jobs:
           rm -f /usr/local/opt/openssl
           ln -s /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
 
-      - uses: msys2/setup-msys2@v2
+      - name: Install tools and libraries via MSYS2
+        uses: msys2/setup-msys2@v2
         if: matrix.platform.os == 'windows'
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
           install: >
             base-devel
             git
             unzip
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-ncurses
-            mingw-w64-x86_64-openssl
-            mingw-w64-x86_64-pcre
-            mingw-w64-x86_64-rust
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-ncurses
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-pcre
+            mingw-w64-ucrt-x86_64-rust
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,19 +58,20 @@ jobs:
           rm -f /usr/local/opt/openssl
           ln -s /usr/local/opt/openssl@1.1 /usr/local/opt/openssl
 
-      - uses: msys2/setup-msys2@v2
+      - name: Install tools and libraries via MSYS2
+        uses: msys2/setup-msys2@v2
         if: matrix.platform.os == 'windows'
         with:
-          msystem: MINGW64
+          msystem: UCRT64
           update: true
           install: >
             base-devel
             git
             unzip
-            mingw-w64-x86_64-toolchain
-            mingw-w64-x86_64-openssl
-            mingw-w64-x86_64-pcre
-            mingw-w64-x86_64-rust
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-openssl
+            mingw-w64-ucrt-x86_64-pcre
+            mingw-w64-ucrt-x86_64-rust
 
       - uses: actions/checkout@v2
         with:

--- a/Makefile
+++ b/Makefile
@@ -189,13 +189,13 @@ ifeq ($(detected_OS),macOS)
   override SSL_LIB_DIR = /usr/local/opt/openssl/lib
  endif
 else ifeq ($(detected_OS),Windows)
- SSL_INCLUDE_DIR ?= /mingw64/include/openssl
+ SSL_INCLUDE_DIR ?= /ucrt64/include/openssl
  ifeq ($(SSL_INCLUDE_DIR),)
-  override SSL_INCLUDE_DIR = /mingw64/include/openssl
+  override SSL_INCLUDE_DIR = /ucrt64/include/openssl
  endif
- SSL_LIB_DIR ?= /mingw64/lib
+ SSL_LIB_DIR ?= /ucrt64/lib
  ifeq ($(SSL_LIB_DIR),)
-  override SSL_LIB_DIR = /mingw64/lib
+  override SSL_LIB_DIR = /ucrt64/lib
  endif
 else
  SSL_INCLUDE_DIR ?= /usr/include
@@ -265,13 +265,13 @@ ifeq ($(detected_OS),macOS)
   override PCRE_LIB_DIR = /usr/local/opt/pcre/lib
  endif
 else ifeq ($(detected_OS),Windows)
- PCRE_INCLUDE_DIR ?= /mingw64/include
+ PCRE_INCLUDE_DIR ?= /ucrt64/include
  ifeq ($(PCRE_INCLUDE_DIR),)
-  override PCRE_INCLUDE_DIR = /mingw64/include
+  override PCRE_INCLUDE_DIR = /ucrt64/include
  endif
- PCRE_LIB_DIR ?= /mingw64/lib
+ PCRE_LIB_DIR ?= /ucrt64/lib
  ifeq ($(PCRE_LIB_DIR),)
-  override PCRE_LIB_DIR = /mingw64/lib
+  override PCRE_LIB_DIR = /ucrt64/lib
  endif
 else
  PCRE_INCLUDE_DIR ?= /usr/include
@@ -312,9 +312,9 @@ ifeq ($(detected_OS),macOS)
   override NCURSES_LIB_DIR = /usr/local/opt/ncurses/lib
  endif
 else ifeq ($(detected_OS),Windows)
- NCURSES_LIB_DIR ?= /mingw64/lib
+ NCURSES_LIB_DIR ?= /ucrt64/lib
  ifeq ($(NCURSES_LIB_DIR),)
-  override NCURSES_LIB_DIR = /mingw64/lib
+  override NCURSES_LIB_DIR = /ucrt64/lib
  endif
 else
  NCURSES_LIB_DIR ?= /usr/lib/x86_64-linux-gnu
@@ -419,7 +419,7 @@ ifeq ($(SQLCIPHER_STATIC),false)
  LD_LIBRARY_PATH_NIMBLE := $(shell pwd)/$(shell dirname $(SQLCIPHER)):$(LD_LIBRARY_PATH_NIMBLE)
 endif
 
-# for NCURSES, PCRE, SSL assume already in PATH of MSYS2 shell, e.g. in /mingw64/bin
+# for NCURSES, PCRE, SSL assume already in PATH of MSYS2 shell, e.g. in /ucrt64/bin
 PATH_NIMBLE := $${PATH}
 ifeq ($(RLN_STATIC),false)
  PATH_NIMBLE := $(RLN_LIB_DIR):$(PATH_NIMBLE)


### PR DESCRIPTION
Gives better compatibility at compile and runtime, and notably better performance re: e.g. disk IO.