### PR TITLE
feat: support importing wallet accout via private key

### DIFF
--- a/examples/chat/client.nim
+++ b/examples/chat/client.nim
@@ -50,6 +50,12 @@ proc stop*(self: ChatClient) {.async.} =
 proc addWalletAccount*(self: ChatClient, name, password: string) {.async.} =
   asyncSpawn addWalletAccount(self.taskRunner, status, name, password)
 
+proc addWalletPrivateKey*(self: ChatClient, name: string, privateKey: string,
+  password: string) {.async.} =
+
+  asyncSpawn addWalletPrivateKey(self.taskRunner, status, name, privateKey,
+    password)
+
 proc connect*(self: ChatClient, username: string) {.async.} =
   asyncSpawn startWakuChat2(self.taskRunner, status, username)
 

--- a/examples/chat/tui/common.nim
+++ b/examples/chat/tui/common.nim
@@ -45,6 +45,11 @@ type
     name*: string
     password*: string
 
+  AddWalletPrivateKey* = ref object of Command
+    name*: string
+    password*: string
+    privateKey*: string
+
   Connect* = ref object of Command
 
   CommandParameter* = ref object of RootObj
@@ -104,7 +109,8 @@ const
 
   commands* = {
     DEFAULT_COMMAND: "SendMessage",
-    "addaccount": "AddWalletAccount",
+    "addwallet": "AddWalletAccount",
+    "addwalletpk": "AddWalletPrivateKey",
     "connect": "Connect",
     "createaccount": "CreateAccount",
     "disconnect": "Disconnect",
@@ -122,7 +128,8 @@ const
 
   aliases* = {
     "?": "help",
-    "add": "addaccount",
+    "add": "addwallet",
+    "addpk": "addwalletpk",
     "create": "createaccount",
     "import": "importmnemonic",
     "join": "jointopic",
@@ -142,7 +149,8 @@ const
 
   aliased* = {
     DEFAULT_COMMAND: @["send"],
-    "addaccount": @["add"],
+    "addwallet": @["add"],
+    "addwalletpk": @["addpk"],
     "createaccount": @["create"],
     "importmnemonic": @["import"],
     "help": @["?"],

--- a/nim_status/accounts/accounts.nim
+++ b/nim_status/accounts/accounts.nim
@@ -3,7 +3,7 @@ import # nim libs
 
 import # vendor libs
   chronos, json_serialization, json_serialization/[reader, writer, lexer],
-  secp256k1, sqlcipher, web3/conversions as web3_conversions, web3/ethtypes
+  secp256k1, sqlcipher
 
 import # nim-status libs
   ../conversions, ../database, ../extkeys/types, ../settings

--- a/nim_status/accounts/generator/generator.nim
+++ b/nim_status/accounts/generator/generator.nim
@@ -229,7 +229,7 @@ proc storeKeyFile*(self: Generator, secretKey: SkSecretKey, password: string,
 
   let
     keyFileJson = $keyFileJsonResult.get
-    now {.used.} = now().format("yyyy-MM-dd'T'HH-mm-ss'.'fffffffff'Z'")
+    now {.used.} = now().utc.format("yyyy-MM-dd'T'HH-mm-ss'.'fffffffff'Z'")
     keyFilePath = dir / fmt"UTC--{now}--{($address).strip0xPrefix}"
 
   dir.createDir()

--- a/nim_status/conversions.nim
+++ b/nim_status/conversions.nim
@@ -2,17 +2,18 @@ import # std libs
   std/[json, options, strutils, times, typetraits]
 
 import # vendor libs
-  chronicles, json_serialization, json_serialization/std/options as json_options,
-  secp256k1, stew/byteutils, sqlcipher, web3/ethtypes
+  chronicles, eth/keys, json_serialization,
+  json_serialization/std/options as json_options, secp256k1, stew/byteutils,
+  sqlcipher, web3/[conversions, ethtypes]
 
 import # nim_status libs
-  ./extkeys/types as key_types, ./settings/types
+  ./extkeys/types as key_types
 
 from ./tx_history/types as tx_history_types import TxType
 
 # needed because nim-sqlcipher calls toDbValue/fromDbValue which does not have
 # json_serialization/std/options imported 
-export json_options
+export conversions, ethtypes, json_options
 
 const dtFormat = "yyyy-MM-dd HH:mm:ss fffffffff"
 
@@ -56,6 +57,12 @@ proc parseAddress*(address: string): Address =
 
 proc readValue*(r: var JsonReader, T: type KeyPath): T =
   KeyPath r.readValue(string)
+
+proc toAddress*(secretKey: SkSecretKey): Address =
+  let
+    publicKey = secretKey.toPublicKey
+    address = (PublicKey publicKey).toAddress
+  address.parseAddress
 
 proc toDbValue*[T: Address](val: T): DbValue =
   DbValue(kind: sqliteText, strVal: $val)

--- a/nim_status/pendingtxs.nim
+++ b/nim_status/pendingtxs.nim
@@ -1,9 +1,11 @@
 import # nim libs
   json, options, strutils, strformat
+
 import # vendor libs
-  web3/conversions as web3_conversions, web3/ethtypes,
-  sqlcipher, json_serialization, json_serialization/[reader, writer, lexer],
-  stew/byteutils
+  json_serialization, json_serialization/[reader, writer, lexer],
+  stew/byteutils, sqlcipher
+
+import ./conversions
 
 type
   PendingTxType* {.pure.} = enum

--- a/nim_status/settings.nim
+++ b/nim_status/settings.nim
@@ -2,7 +2,7 @@ import # nim libs
   std/[json, options, strutils, strformat]
 
 import # vendor libs
-  json_serialization, sqlcipher, web3/conversions as web3_conversions 
+  json_serialization, sqlcipher
 
 import # nim-status libs
   ./conversions, ./settings/types

--- a/nim_status/settings/types.nim
+++ b/nim_status/settings/types.nim
@@ -4,11 +4,10 @@ import # nim libs
 
 import # vendor libs
   json_serialization, json_serialization/[reader, writer, lexer],
-  json_serialization/std/options as json_options,
-  web3/conversions as web3_conversions, web3/ethtypes, sqlcipher
+  json_serialization/std/options as json_options, sqlcipher
 
 import # nim-status libs
-  ../networks
+  ../conversions, ../networks
 
 export networks
 

--- a/nim_status/tokens.nim
+++ b/nim_status/tokens.nim
@@ -2,7 +2,6 @@ import # nim libs
   json, options, strutils, strformat
 
 import # vendor libs
-  web3/conversions as web3_conversions,
   web3/ethtypes,
   sqlcipher, json_serialization,
   json_serialization/[reader, writer, lexer]

--- a/nim_status/tx_history.nim
+++ b/nim_status/tx_history.nim
@@ -7,7 +7,6 @@ import sets
 import tables
 import rlocks
 import # vendor libs
-  web3/conversions as web3_conversions, web3/ethtypes,
   sqlcipher, json_serialization, json_serialization/[reader, writer, lexer],
   stew/byteutils
 

--- a/test/accounts/public_accounts.nim
+++ b/test/accounts/public_accounts.nim
@@ -2,7 +2,7 @@ import # nim libs
   json, options, os, times, unittest
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher, web3/conversions as web3_conversions
+  chronos, json_serialization, sqlcipher
 
 import # nim-status libs
   ../../nim_status/[database, conversions],

--- a/test/chats.nim
+++ b/test/chats.nim
@@ -2,8 +2,7 @@ import # nim libs
   json, options, os, unittest
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher, stew/byteutils,
-  web3/conversions as web3_conversions
+  chronos, json_serialization, sqlcipher, stew/byteutils
 
 import # nim-status libs
   ../nim_status/[chats, contacts, conversions, database, messages],

--- a/test/client.nim
+++ b/test/client.nim
@@ -2,8 +2,7 @@ import # nim libs
   std/[json, options, os, unittest]
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher,
-  web3/conversions as web3_conversions
+  chronos, json_serialization, sqlcipher
 
 import # nim-status libs
   ../nim_status/[client, conversions, database, settings],

--- a/test/contacts.nim
+++ b/test/contacts.nim
@@ -2,8 +2,7 @@ import # nim libs
   json, options, os, unittest
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher, web3/conversions as web3_conversions,
-  web3/ethtypes
+  chronos, json_serialization, sqlcipher
 
 import # nim-status libs
   ../nim_status/[contacts, conversions, database],

--- a/test/messages.nim
+++ b/test/messages.nim
@@ -2,8 +2,7 @@ import # nim libs
   json, options, os, unittest
 
 import # vendor libs
-  json_serialization, sqlcipher, stew/byteutils,
-  web3/conversions as web3_conversions
+  json_serialization, sqlcipher, stew/byteutils
 
 import # nim-status libs
   ../nim_status/[conversions, chats, database, messages],

--- a/test/multiaccount.nim
+++ b/test/multiaccount.nim
@@ -5,7 +5,7 @@ import # vednor libs
   chronos, eth/[keys, p2p], stew/byteutils
 
 import # nim-status libs
-  ../nim_status/accounts/generator/generator, ../nim_status/extkeys/paths,
+  ../nim_status/[accounts/generator/generator, conversions, extkeys/paths],
   ./test_helpers
 
 
@@ -55,13 +55,13 @@ procSuite "multiaccount":
 
     let
       storeDerivedAccs = storeDerivedAccsResult.get
-      chatAddress = storeDerivedAccs[paths[2]].address
+      chatAddress = storeDerivedAccs[paths[2]].address.parseAddress
       loadAccResult = gntr.loadAccount(chatAddress, password, dir)
 
     assert loadAccResult.isOk, "failed loading account"
 
     let loadAcc = loadAccResult.get
 
-    assert loadAcc.address == chatAddress
+    assert loadAcc.address.parseAddress == chatAddress
 
     removeDir(dir)

--- a/test/pendingtxs.nim
+++ b/test/pendingtxs.nim
@@ -2,10 +2,10 @@ import # nim libs
   std/[json, options, os, unittest]
 
 import # vendor libs
-  chronos, json_serialization, sqlcipher, web3/conversions as web3_conversions
+  chronos, json_serialization, sqlcipher
 
 import # nim-status libs
-  ../nim_status/[database, pendingtxs], ./test_helpers
+  ../nim_status/[conversions, database, pendingtxs], ./test_helpers
 
 procSuite "pendingtxs":
   asyncTest "pendingtxs":

--- a/test/settings.nim
+++ b/test/settings.nim
@@ -3,7 +3,7 @@ import # nim libs
 
 import # vendor libs
   chronos, json_serialization, json_serialization/std/options as json_options,
-  sqlcipher, web3/conversions as web3_conversions, web3/ethtypes
+  sqlcipher
 
 import # nim-status libs
   ../nim_status/[conversions, database, settings],

--- a/test/tx_history.nim
+++ b/test/tx_history.nim
@@ -2,11 +2,10 @@ import # nim libs
   std/[os, json, options, tables]
 
 import # vendor libs
-  sqlcipher, json_serialization, web3/conversions as web3_conversions
+  sqlcipher, json_serialization
 
 import # nim-status libs
-  ../../nim_status/[settings, database, callrpc],
-  ../../nim_status/tx_history/types
+  ../../nim_status/[conversions, callrpc, database, settings, tx_history/types]
 
 from ../../nim_status/tx_history import nil
 


### PR DESCRIPTION
Closes: #197 

Add funcs to support importing a wallet account via private key.

Support password validation before importing the keystore file. Prevent duplicate keystore files from being imported.

Add keystore file unit tests for storing and loading of key files

Add import wallet pk command to example chat client

Refactor web3_conversions imports to insteaad import `nim_status/conversions`.