### PR TITLE
feat: import wallet account via mnemonic

### DIFF
--- a/examples/chat/client.nim
+++ b/examples/chat/client.nim
@@ -56,6 +56,12 @@ proc addWalletPrivateKey*(self: ChatClient, name: string, privateKey: string,
   asyncSpawn addWalletPrivateKey(self.taskRunner, status, name, privateKey,
     password)
 
+proc addWalletSeed*(self: ChatClient, name, mnemonic, password,
+  bip39passphrase: string) {.async.} =
+
+  asyncSpawn addWalletSeed(self.taskRunner, status, name, mnemonic,
+    password, bip39passphrase)
+
 proc connect*(self: ChatClient, username: string) {.async.} =
   asyncSpawn startWakuChat2(self.taskRunner, status, username)
 

--- a/examples/chat/tui/common.nim
+++ b/examples/chat/tui/common.nim
@@ -50,6 +50,12 @@ type
     password*: string
     privateKey*: string
 
+  AddWalletSeed* = ref object of Command
+    bip39Passphrase*: string
+    name*: string
+    mnemonic*: string
+    password*: string
+
   Connect* = ref object of Command
 
   CommandParameter* = ref object of RootObj
@@ -111,6 +117,7 @@ const
     DEFAULT_COMMAND: "SendMessage",
     "addwallet": "AddWalletAccount",
     "addwalletpk": "AddWalletPrivateKey",
+    "addwalletseed": "AddWalletSeed",
     "connect": "Connect",
     "createaccount": "CreateAccount",
     "disconnect": "Disconnect",
@@ -130,6 +137,7 @@ const
     "?": "help",
     "add": "addwallet",
     "addpk": "addwalletpk",
+    "addseed": "addwalletseed",
     "create": "createaccount",
     "import": "importmnemonic",
     "join": "jointopic",
@@ -151,6 +159,7 @@ const
     DEFAULT_COMMAND: @["send"],
     "addwallet": @["add"],
     "addwalletpk": @["addpk"],
+    "addwalletseed": @["addseed"],
     "createaccount": @["create"],
     "importmnemonic": @["import"],
     "help": @["?"],

--- a/nim_status/accounts/generator/generator.nim
+++ b/nim_status/accounts/generator/generator.nim
@@ -57,7 +57,7 @@ proc addAccount(self: Generator, acc: Account): AddAccountResult =
   AddAccountResult.ok(uuid)
 
 proc deriveChildAccount(self: Generator, a: Account,
-  path: KeyPath): DeriveChildAccountResult =
+  path: KeyPath): DeriveChildAccountResult {.used.} =
 
   let
     childExtKey = ?a.extendedKey.derive(path)


### PR DESCRIPTION
Closes: #224.

Allows a user to import a wallet account via 12-word mnemonic seed.

The account is first imported in the account generator. Then a wallet account is derived at the root wallet path (m/44'/60’/0’/0/0) from the master key of the mnemonic. This account is then stored in the Accounts table of the user’s db.