### PR TITLE
feat: Add watch-only wallet account

### DIFF
--- a/examples/chat/client.nim
+++ b/examples/chat/client.nim
@@ -62,6 +62,9 @@ proc addWalletSeed*(self: ChatClient, name, mnemonic, password,
   asyncSpawn addWalletSeed(self.taskRunner, status, name, mnemonic,
     password, bip39passphrase)
 
+proc addWalletWatchOnly*(self: ChatClient, address, name: string) {.async.} =
+  asyncSpawn addWalletWatchOnly(self.taskRunner, status, address, name)
+
 proc connect*(self: ChatClient, username: string) {.async.} =
   asyncSpawn startWakuChat2(self.taskRunner, status, username)
 

--- a/examples/chat/tui/commands.nim
+++ b/examples/chat/tui/commands.nim
@@ -180,6 +180,47 @@ proc command*(self: ChatTUI, command: AddWalletSeed) {.async, gcsafe,
     asyncSpawn self.client.addWalletSeed(command.name,
       command.mnemonic, command.password, command.bip39Passphrase)
 
+# AddWalletWatchOnly ------------------------------------------------------------
+
+proc help*(T: type AddWalletWatchOnly): HelpText =
+  let command = "addwalletseed"
+  HelpText(command: command, aliases: aliased[command], parameters: @[
+    CommandParameter(name: "name", description: "(Optional) Display name for " &
+      "the new account."),
+    CommandParameter(name: "address", description: "The address of the " &
+      "account to watch.")
+    ], description: "Watches the transactions in a wallet account, without " &
+      "the ability to interact with the wallet (ie sign transactions).")
+
+proc new*(T: type AddWalletWatchOnly, args: varargs[string]): T =
+  T(name: args[0], address: args[1])
+
+proc split*(T: type AddWalletWatchOnly, argsRaw: string): seq[string] =
+  var args = argsRaw.split(" ")
+  args.keepIf(arg => arg != "")
+
+  var
+    name = ""
+    address= ""
+
+  if args.len == 1:
+    name = ""
+    address = args[0]
+  elif args.len > 1:
+    name = args[0]
+    address = args[1]
+
+  @[name, address]
+
+proc command*(self: ChatTUI, command: AddWalletWatchOnly) {.async, gcsafe,
+  nimcall.} =
+
+  if command.address == "":
+    self.wprintFormatError(getTime().toUnix(),
+      "address cannot be blank.")
+  else:
+    asyncSpawn self.client.addWalletWatchOnly(command.address, command.name)
+
 # Connect ----------------------------------------------------------------------
 
 proc help*(T: type Connect): HelpText =

--- a/examples/chat/tui/common.nim
+++ b/examples/chat/tui/common.nim
@@ -56,6 +56,10 @@ type
     mnemonic*: string
     password*: string
 
+  AddWalletWatchOnly* = ref object of Command
+    name*: string
+    address*: string
+
   Connect* = ref object of Command
 
   CommandParameter* = ref object of RootObj
@@ -118,6 +122,7 @@ const
     "addwallet": "AddWalletAccount",
     "addwalletpk": "AddWalletPrivateKey",
     "addwalletseed": "AddWalletSeed",
+    "addwalletwatch": "AddWalletWatchOnly",
     "connect": "Connect",
     "createaccount": "CreateAccount",
     "disconnect": "Disconnect",
@@ -138,6 +143,7 @@ const
     "add": "addwallet",
     "addpk": "addwalletpk",
     "addseed": "addwalletseed",
+    "addwatch": "addwalletwatch",
     "create": "createaccount",
     "import": "importmnemonic",
     "join": "jointopic",
@@ -160,6 +166,7 @@ const
     "addwallet": @["add"],
     "addwalletpk": @["addpk"],
     "addwalletseed": @["addseed"],
+    "addwalletwatch": @["addwatch"],
     "createaccount": @["create"],
     "importmnemonic": @["import"],
     "help": @["?"],


### PR DESCRIPTION
Closes: #226

Add command (`/addwalletwatch`, `/addwatch`) that allows adding a watch-only account to the example client.