### PR TITLE
refactor: use SQLCipher v4 defaults re: algorithms, iterations, etc.

### DIFF
--- a/nim_status/database.nim
+++ b/nim_status/database.nim
@@ -32,10 +32,18 @@ proc initializeDB*(path, password: string): DbConn =
     runMigrations = true
   result = openDatabase(path)
   result.key(password.hash)
-  result.exec("PRAGMA cipher_page_size = 1024")
-  result.exec("PRAGMA kdf_iter = 3200")
-  result.exec("PRAGMA cipher_hmac_algorithm = HMAC_SHA1")
-  result.exec("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1")
+  # Custom encryption settings are used by status-go with sqlcipher v3 to
+  # accommodate lower-performance mobile devices. See:
+  # * https://github.com/status-im/status-go/pull/1343
+  # * https://github.com/status-im/status-go/blob/81171ad9e64feeceff81bc78b1aefba196cb1172/sqlite/sqlite.go#L12-L21
+  # nim-status will instead use sqlcipher v4's defaults, but in the future we
+  # may need to allow custom settings to be specified at compile time.
+  # ----------------------------------------------------------------------------
+  # result.exec("PRAGMA cipher_page_size = 1024")
+  # result.exec("PRAGMA kdf_iter = 3200")
+  # result.exec("PRAGMA cipher_hmac_algorithm = HMAC_SHA1")
+  # result.exec("PRAGMA cipher_kdf_algorithm = PBKDF2_HMAC_SHA1")
+  # ----------------------------------------------------------------------------
   result.exec("PRAGMA foreign_keys = ON")
   result.exec("PRAGMA journal_mode = WAL")
   if runMigrations:


### PR DESCRIPTION
Comment out and provide an explanatory comment re: the custom settings that we originally carried over from status-go.

Closes #209.