### PR TITLE
feat(client): basic support for backspace

### DIFF
--- a/examples/client/tui/actions.nim
+++ b/examples/client/tui/actions.nim
@@ -27,6 +27,8 @@ logScope:
 # at least 60 FPS in the TUI.
 
 const
+  KEY_BACKSPACE = "KEY_BACKSPACE"
+  KEY_DC = "KEY_DC"
   KEY_MOUSE = "KEY_MOUSE"
   KEY_RESIZE = "KEY_RESIZE"
 
@@ -51,6 +53,12 @@ proc action*(self: Tui, event: InputKey) {.async, gcsafe, nimcall.} =
     case name:
       of ESCAPE:
         discard
+
+      of KEY_BACKSPACE:
+        self.deleteBackward()
+
+      of KEY_DC:
+        self.deleteForward()
 
       of KEY_MOUSE:
         var me: MEvent

--- a/examples/client/tui/screen.nim
+++ b/examples/client/tui/screen.nim
@@ -44,6 +44,52 @@ proc colors() =
   init_pair(7, COLOR_GREEN, -1)
   init_pair(8, COLOR_WHITE, COLOR_RED)
 
+proc deleteBackward*(self: Tui) =
+  let inputLen = self.currentInput.len
+  if inputLen > 0:
+    # when cursor is able to be moved with arrow keys, modifying
+    # self.currentInput needs to take into account current cursor
+    # position and geometry of self.inputWin
+    self.currentInput.setLen(inputLen - 1)
+
+    # adapted from: https://stackoverflow.com/a/55148654
+
+    let inputWin = self.inputWin
+    var y, x: cint
+    getyx(inputWin, y, x)
+
+    if x == 0.cint:
+      if y == 0.cint:
+        return
+
+      x = getmaxx(inputWin)
+      y = y - 1.cint
+      wmove(inputWin, y, x)
+
+      var ch = ' '.chtype
+      while ch == ' '.chtype and x != 0.cint:
+        x = x - 1.cint
+        wmove(inputWin, y, x)
+        ch = winch(inputWin)
+
+    else:
+      wmove(inputWin, y, x - 1.cint)
+
+    wdelch(inputWin)
+    wrefresh(inputWin)
+
+    trace "TUI backward-deleted in input window"
+
+proc deleteForward*(self: Tui) =
+  # implement when cursor is able to be moved with arrow keys; modifying
+  # self.currentInput and forward-deleting a char in self.inputWin needs
+  # to take into account current cursor position and geometry of
+  # self.inputWin
+
+  # trace "TUI forward-deleted in input window"
+
+  warn "TUI has no implementation for forward-deletion"
+
 proc drawOutputWin*(self: Tui) =
   # create subwindow for output box
   self.outputWinBox = subwin(self.mainWin, (LINES.float64 * 0.8).cint, COLS, 0, 0)

--- a/examples/client/tui/tasks.nim
+++ b/examples/client/tui/tasks.nim
@@ -49,12 +49,23 @@ proc readInput*() {.task(kind=no_rts, stoppable=false).} =
       var
         eventEnc: string
         shouldSend = false
-      if input > 255 or input == 10 or input == 27:
+      if input > 255 or input == 8 or input == 10 or input == 27 or
+         input == 127:
         var event: InputKey
-        if input == 10:
+        if input == 8:
+          # interpret as backspace key
+          event = InputKey(key: 263, name: $keyname(263.cint))
+        elif input == 10:
           event = InputKey(key: input, name: RETURN)
         elif input == 27:
           event = InputKey(key: input, name: ESCAPE)
+        elif input == 127:
+          if defined(macosx):
+            # interpret as backspace key
+            event = InputKey(key: 263, name: $keyname(263.cint))
+          else:
+            # interpret as delete key
+            event = InputKey(key: 330, name: $keyname(330.cint))
         else:
           event = InputKey(key: input, name: $keyname(input.cint))
         eventEnc = event.encode


### PR DESCRIPTION
Note: on mac keyboards the delete key is backspace and on mac laptop keyboards fn+delete is delete ("forward delete"). Some mac keyboards have a separate key, also named delete, for performing forward deletion.

---

After I've tested locally on Linux and Windows, I'll take this PR out of draft.

Tested on:
- [x] macOS
- [x] Linux
- [x] Windows