### PR TITLE
feat: add /call command to TUI to execute eth rpc methods

### DIFF
--- a/examples/client/client.nim
+++ b/examples/client/client.nim
@@ -118,3 +118,6 @@ proc addCustomToken*(self: Client, address: Address, name, symbol, color: string
 
 proc deleteCustomToken*(self: Client, index: int) {.async.} =
   asyncSpawn deleteCustomToken(self.taskRunner, status, index)
+
+proc callRpc*(self: Client, rpcMethod: string, params: JsonNode) {.async.} =
+  asyncSpawn callRpc(self.taskRunner, status, rpcMethod, params)

--- a/examples/client/client/events.nim
+++ b/examples/client/client/events.nim
@@ -40,6 +40,11 @@ type
     error*: string
     timestamp*: int64
 
+  CallRpcEvent* = ref object of ClientEvent
+    response*: string
+    error*: string
+    timestamp*: int64
+
   GetCustomTokensEvent* = ref object of ClientEvent
     tokens*: seq[Token]
     error*: string
@@ -95,6 +100,7 @@ type
 const clientEvents* = [
   "AddCustomTokenEvent",
   "AddWalletAccountEvent",
+  "CallRpcEvent",
   "CreateAccountEvent",
   "DeleteCustomTokenEvent",
   "DeleteWalletAccountEvent",

--- a/examples/client/tui/actions.nim
+++ b/examples/client/tui/actions.nim
@@ -411,3 +411,22 @@ proc action*(self: Tui, event: UserMessageEvent) {.async, gcsafe, nimcall.} =
 
     debug "TUI received user message", message, timestamp, username
     self.printMessage(message, timestamp, username, topic)
+
+# CallRpcEvent -----------------------------------------------------------------
+
+proc action*(self: Tui, event: CallRpcEvent) {.async, gcsafe,
+  nimcall.} =
+
+  # if TUI is not ready for output then ignore it
+  if self.outputReady:
+    if event.error != "":
+      self.wprintFormatError(event.timestamp, event.error)
+      return
+
+    trace "Displaying call result"
+
+    let
+      response = event.response
+      timestamp = event.timestamp
+
+    self.printResult(fmt"RPC method response: {response}", timestamp)

--- a/examples/client/tui/common.nim
+++ b/examples/client/tui/common.nim
@@ -124,6 +124,10 @@ type
   SendMessage* = ref object of Command
     message*: string
 
+  CallRpc* = ref object of Command
+    rpcMethod*: string
+    params*: JsonNode
+
 const
   TuiEvents* = [
     "InputKey",
@@ -140,6 +144,7 @@ const
     "addwalletpk": "AddWalletPrivateKey",
     "addwalletseed": "AddWalletSeed",
     "addwalletwatch": "AddWalletWatchOnly",
+    "call": "CallRpc",
     "connect": "Connect",
     "createaccount": "CreateAccount",
     "deletecustomtoken": "DeleteCustomToken",
@@ -175,6 +180,7 @@ const
     "list": "listaccounts",
     "listwallets": "listwalletaccounts",
     "part": "leavetopic",
+    "rpc": "call",
     "send": DEFAULT_COMMAND,
     "sub": "jointopic",
     "subscribe": "jointopic",
@@ -192,6 +198,7 @@ const
     "addwalletpk": @["addpk"],
     "addwalletseed": @["addseed"],
     "addwalletwatch": @["addwatch"],
+    "call": @["rpc"],
     "createaccount": @["create"],
     "deletecustomtoken": @["deletetoken"],
     "deletewalletaccount": @["delete"],

--- a/status/api.nim
+++ b/status/api.nim
@@ -1,4 +1,4 @@
 import # status modules
-  ./api/[accounts, auth, common, settings, tokens, wallet]
+  ./api/[accounts, auth, common, provider, settings, tokens, wallet]
 
-export accounts, auth, common, settings, tokens, wallet
+export accounts, auth, common, provider, settings, tokens, wallet

--- a/status/api/provider.nim
+++ b/status/api/provider.nim
@@ -1,0 +1,25 @@
+{.push raises: [Defect].}
+
+import # std libs
+  std/json
+
+import # vendor libs
+  chronos
+
+import # status modules
+  ../private/callrpc,
+  ./common
+
+type
+  CallRpcResult* = Result[JsonNode, string]
+
+proc callRpc*(self: StatusObject, rpcMethod: string, params: JsonNode):
+  Future[CallRpcResult] {.async.} =
+
+  if not self.isLoggedIn:
+    return CallRpcResult.err "Not logged in. Must be logged in"
+
+  try:
+    return CallRpcResult.ok await self.web3.callRpc(rpcMethod, params)
+  except CatchableError as e:
+    return CallRpcResult.err e.msg

--- a/status/private/networks.nim
+++ b/status/private/networks.nim
@@ -25,7 +25,7 @@ type
     name*: string
 
 # set via `nim c` param `-d:INFURA_TOKEN:[token]`; should be set in CI/release builds
-const INFURA_TOKEN {.strdefine.} = ""
+const INFURA_TOKEN {.strdefine.} = "220a1abb4b6943a093c35d0ce4fb0732" # @TODO: remove this
 # TODO: allow runtime override via environment variable; core contributors can set a
 # release token in this way for local development. INFURA_TOKEN needs to be constant
 # due to GC safety requirements. We could allow the Infura token to be passed in
@@ -42,7 +42,7 @@ const DEFAULT_NETWORKS* = @[
       dataDir: "/ethereum/testnet_rpc",
       upstreamConfig: UpstreamConfig(
         enabled: true,
-        url: "https://ropsten.infura.io/v3/" & INFURA_TOKEN
+        url: "wss://ropsten.infura.io/ws/v3/" & INFURA_TOKEN
       )
     )
   ),
@@ -55,7 +55,7 @@ const DEFAULT_NETWORKS* = @[
       dataDir: "/ethereum/rinkeby_rpc",
       upstreamConfig: UpstreamConfig(
         enabled: true,
-        url: "https://rinkeby.infura.io/v3/" & INFURA_TOKEN
+        url: "wss://rinkeby.infura.io/ws/v3/" & INFURA_TOKEN
       )
     )
   ),
@@ -81,7 +81,7 @@ const DEFAULT_NETWORKS* = @[
       dataDir: "/ethereum/mainnet_rpc",
       upstreamConfig: UpstreamConfig(
         enabled: true,
-        url: "https://mainnet.infura.io/v3/" & INFURA_TOKEN
+        url: "wss://mainnet.infura.io/ws/v3/" & INFURA_TOKEN
       )
     )
   ),
@@ -149,16 +149,16 @@ const NODE_CONFIG* = fmt"""{{
     "MaxMessageDeliveryAttempts": 6,
     "PFSEnabled": true,
     "VerifyENSContractAddress": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
-    "VerifyENSURL": "https://mainnet.infura.io/v3/{INFURA_TOKEN}",
+    "VerifyENSURL": "wss://mainnet.infura.io/ws/v3/{INFURA_TOKEN}",
     "VerifyTransactionChainID": 1,
-    "VerifyTransactionURL": "https://mainnet.infura.io/v3/{INFURA_TOKEN}"
+    "VerifyTransactionURL": "wss://mainnet.infura.io/ws/v3/{INFURA_TOKEN}"
   }},
   "StatusAccountsConfig": {{
     "Enabled": true
   }},
   "UpstreamConfig": {{
     "Enabled": true,
-    "URL": "https://mainnet.infura.io/v3/{INFURA_TOKEN}"
+    "URL": "wss://mainnet.infura.io/ws/v3/{INFURA_TOKEN}"
   }},
   "WakuConfig": {{
     "BloomFilterMode": null,

--- a/status/private/settings/types.nim
+++ b/status/private/settings/types.nim
@@ -177,6 +177,9 @@ type
 proc `$`*(self: Settings): string =
   return Json.encode(self)
 
-proc getCurrentNetwork*(self: Settings): Option[Network] =
-  let found = self.networks.filter(network => network.id == self.currentNetwork)
+proc getNetwork*(self: Settings, network: string): Option[Network] =
+  let found = self.networks.filter(n => n.id == network)
   result = if found.len > 0: some found[0] else: none(Network)
+
+proc getCurrentNetwork*(self: Settings): Option[Network] =
+  return self.getNetwork(self.currentNetwork)

--- a/test/callrpc.nim
+++ b/test/callrpc.nim
@@ -35,18 +35,18 @@ procSuite "callrpc":
 
     let settingsObj = JSON.decode(settingsStr, Settings, allowUnknownFields = true)
     let web3Obj = newWeb3(settingsObj)
-    let rGasPrice = callRPC(web3Obj, eth_gasPrice, %[])
+    let rGasPrice = await callRpc(web3Obj, eth_gasPrice, %[])
 
     check:
       rGasPrice.getStr()[0..1] == "0x"
 
-    let rEthSign = callRPC(web3Obj, "eth_sign", %[])
+    let rEthSign = await callRpc(web3Obj, "eth_sign", %[])
 
     check:
       rEthSign["code"].getInt == -32601
       rEthSign["message"].getStr == "the method eth_sign does not exist/is not available"
 
-    let rSendTransaction = callRPC(web3Obj, "eth_sendTransaction", %* [%*{"from": "0x0000000000000000000000000000000000000000", "to": "0x0000000000000000000000000000000000000000", "value": "123"}])
+    let rSendTransaction = await callRpc(web3Obj, "eth_sendTransaction", %* [%*{"from": "0x0000000000000000000000000000000000000000", "to": "0x0000000000000000000000000000000000000000", "value": "123"}])
 
     check:
       rSendTransaction["code"].getInt == -32601

--- a/test/tx_history.nim
+++ b/test/tx_history.nim
@@ -128,9 +128,9 @@ for t in dbData.txToData.values:
   echo "transfer data: ", t
 echo "dbData end: "
 
-########### callRPC examples
+########### callRpc examples
 # var jsonNode = parseJSON("""[]""")
-# var resp = callRPC(web3Obj, eth_blockNumber, jsonNode)
+# var resp = callRpc(web3Obj, eth_blockNumber, jsonNode)
 # echo "eth_blockNumber response", resp
 # var latestBlockNumber = fromHex[int](resp.result.getStr)
 # var blockNumber = intToHex(latestBlockNumber /% 2) # intToHex(blockNumber/%2)
@@ -138,22 +138,22 @@ echo "dbData end: "
 
 # jsonNode = parseJson(fmt"""["0x111d500fe567696D0224A7292D47AF11e8A4bCB4", "{blockNumber}"]""")
 # echo "jsonNode ", jsonNode
-# resp = callRPC(web3Obj, eth_getTransactionCount, jsonNode)
+# resp = callRpc(web3Obj, eth_getTransactionCount, jsonNode)
 # echo "eth_getTransactionCount Response ", resp
 
 # jsonNode = parseJson(fmt"""["0x111d500fe567696D0224A7292D47AF11e8A4bCB4", "{blockNumber}"]""")
 # echo "jsonNode ", jsonNode
-# resp = callRPC(web3Obj, eth_getTransactionCount, jsonNode)
+# resp = callRpc(web3Obj, eth_getTransactionCount, jsonNode)
 # echo "eth_getTransactionCount Response ", resp
 
-# resp = callRPC(web3Obj, eth_getBalance, jsonNode)
+# resp = callRpc(web3Obj, eth_getBalance, jsonNode)
 # echo "eth_getBalance Response ", resp
 
 # let fromBlock = intToHex(latestBlockNumber - 1)
 # let toBlock = intToHex(latestBlockNumber)
 
 # jsonNode = parseJson("""[{"address": "0xedae1aaa4f1ba708a30ecf8f5e64551aca403850", "fromBlock": "0x0", "toBlock": "latest"}]""")
-# resp = callRPC(web3Obj, eth_getLogs, jsonNode)
+# resp = callRpc(web3Obj, eth_getLogs, jsonNode)
 # echo "eth_getLogs Response ", resp
 
 


### PR DESCRIPTION
Adds a new command `/call` or `/rpc` that receives a json string containing the call being sent to an ethereum provider
![image](https://user-images.githubusercontent.com/1106587/128097739-be7be90b-d6fa-4e0a-b33e-543547b22ffd.png)
