### PR TITLE
refactor: example client does not import non-api modules of nim-status

### DIFF
--- a/examples/client/client/common.nim
+++ b/examples/client/client/common.nim
@@ -5,12 +5,12 @@ import # vendor libs
   task_runner
 
 import # status lib
-  ../../../status/private/accounts/public_accounts
+  ../../../status/api/accounts
 
 import # client modules
   ../config
 
-export config, public_accounts, sets, strformat, strutils, task_runner, times
+export accounts, config, sets, strformat, strutils, task_runner, times
 
 logScope:
   topics = "client"

--- a/examples/client/client/events.nim
+++ b/examples/client/client/events.nim
@@ -2,7 +2,7 @@ import # vendor libs
   web3/ethtypes
 
 import # status lib
-  ../../../status/[api, private/tokens]
+  ../../../status/api/[tokens, wallet]
 
 import # client modules
   ./common

--- a/examples/client/client/tasks.nim
+++ b/examples/client/client/tasks.nim
@@ -7,14 +7,13 @@ import # vendor libs
   stew/byteutils
 
 import # status lib
-  ../../status/api,
-  ../../status/private/accounts/[accounts, public_accounts],
-  ../../status/private/[alias, conversions, database, extkeys/types, protocol]
+  ../../status/api/[tokens, wallet],
+  ../../status/private/protocol
 
 import # client modules
   ./events, ./waku_chat2
 
-export conversions, events
+export events
 
 logScope:
   topics = "client"

--- a/status.nim
+++ b/status.nim
@@ -1,6 +1,4 @@
 import # status modules
-  ./status/[account, accounts, alias, chats, client, identicon, messages,
-            permissions, util]
+  ./status/api
 
-export account, accounts, alias, chats, client, identicon, messages,
-       permissions, util
+export api


### PR DESCRIPTION
There's one remaining import of a non-api (private) module in `examples/client/client/tasks.nim`:

```
../../status/private/protocol
```

That one will be removed in a forthcoming PR that moves import/usage of nim-waku from the example client to the nim-status library itself.