### PR TITLE
feat: add /sendtransaction command to TUI

### DIFF
--- a/examples/client/client.nim
+++ b/examples/client/client.nim
@@ -4,6 +4,9 @@ import # std libs
 import # client modules
   ./client/tasks
 
+import # vendor libs
+  eth/common
+
 export tasks
 
 logScope:
@@ -124,3 +127,6 @@ proc deleteCustomToken*(self: Client, index: int) {.async.} =
 
 proc callRpc*(self: Client, rpcMethod: string, params: JsonNode) {.async.} =
   asyncSpawn callRpc(self.taskRunner, status, rpcMethod, params)
+
+proc sendTransaction*(self: Client, fromAddress: EthAddress, transaction: Transaction, password: string) {.async.} =
+  asyncSpawn sendTransaction(self.taskRunner, status, fromAddress, transaction, password)

--- a/examples/client/client/events.nim
+++ b/examples/client/client/events.nim
@@ -96,6 +96,11 @@ type
   NetworkStatusEvent* = ref object of ClientEvent
     online*: bool
 
+  SendTransactionEvent* = ref object of ClientEvent
+    response*: string
+    error*: string
+    timestamp*: int64
+
   UserMessageEvent* = ref object of ClientEvent
     message*: string
     timestamp*: int64
@@ -119,6 +124,7 @@ const clientEvents* = [
   "LoginEvent",
   "LogoutEvent",
   "NetworkStatusEvent",
+  "SendTransactionEvent",
   "UserMessageEvent"
 ]
 

--- a/examples/client/client/serialization.nim
+++ b/examples/client/client/serialization.nim
@@ -1,0 +1,8 @@
+import # vendor libs
+  eth/common, json_serialization
+
+proc writeValue*(writer: var JsonWriter, value: ChainId) =
+  writeValue(writer, uint64 value)
+
+proc readValue*(reader: var JsonReader, value: var ChainId) =
+  value = ChainId reader.readValue(uint64)

--- a/examples/client/tui/actions.nim
+++ b/examples/client/tui/actions.nim
@@ -470,3 +470,20 @@ proc action*(self: Tui, event: CallRpcEvent) {.async, gcsafe,
       timestamp = event.timestamp
 
     self.printResult(fmt"RPC method response: {response}", timestamp)
+
+# SendTransactionEvent ---------------------------------------------------------
+
+proc action*(self: Tui, event: SendTransactionEvent) {.async, gcsafe,
+  nimcall.} =
+
+  # if TUI is not ready for output then ignore it
+  if self.outputReady:
+    if event.error != "":
+      self.wprintFormatError(event.timestamp, event.error)
+      return
+
+    let
+      response = event.response
+      timestamp = event.timestamp
+
+    self.printResult(fmt"eth_sendTransaction response: {response}", timestamp)

--- a/examples/client/tui/common.nim
+++ b/examples/client/tui/common.nim
@@ -1,6 +1,9 @@
 import # client modules
   ../client, ./ncurses_helpers
 
+import # vendor libs
+  eth/common
+
 export client, ncurses_helpers
 
 logScope:
@@ -67,6 +70,10 @@ type
     name*: string
     address*: string
 
+  CallRpc* = ref object of Command
+    rpcMethod*: string
+    params*: string
+
   Connect* = ref object of Command
 
   CommandParameter* = ref object of RootObj
@@ -127,9 +134,16 @@ type
   SendMessage* = ref object of Command
     message*: string
 
-  CallRpc* = ref object of Command
-    rpcMethod*: string
-    params*: JsonNode
+  SendTransaction* = ref object of Command
+    fromAddress*: string
+    toAddress*: string
+    value*: string
+    maxPriorityFee*: string
+    maxFee*: string
+    gasLimit*: string
+    payload*: string
+    nonce*: string
+    password*: string
 
 const
   TuiEvents* = [
@@ -164,6 +178,7 @@ const
     "listtopics": "ListTopics",
     "login": "Login",
     "logout": "Logout",
+    "sendtransaction": "SendTransaction",
     "quit": "Quit"
   }.toTable
 
@@ -190,6 +205,7 @@ const
     "sub": "jointopic",
     "subscribe": "jointopic",
     "topics": "listtopics",
+    "trx": "sendtransaction",
     "unjoin": "leavetopic",
     "unsub": "leavetopic",
     "unsubscribe": "leavetopic",
@@ -215,7 +231,8 @@ const
     "leavetopic": @["leave", "part", "unjoin", "unsub", "unsubscribe"],
     "listaccounts": @["list"],
     "listtopics": @["topics"],
-    "listwalletaccounts": @["listwallets", "wallets"]
+    "listwalletaccounts": @["listwallets", "wallets"],
+    "sendtransaction": @["trx"]
   }.toTable
 
 proc stop*(self: Tui) {.async.} =

--- a/status/api/provider.nim
+++ b/status/api/provider.nim
@@ -1,17 +1,22 @@
 {.push raises: [Defect].}
 
 import # std libs
-  std/json
+  std/[json, sequtils, sugar]
 
 import # vendor libs
-  chronos
+  chronicles, chronos,
+  eth/common as eth_common,
+  eth/[common/transaction, keys, rlp],
+  stew/byteutils
 
 import # status modules
-  ../private/callrpc,
+  ../private/[accounts/accounts, accounts/generator/generator, callrpc, settings],
   ./common
 
 type
   CallRpcResult* = Result[JsonNode, string]
+
+  SendTransactionResult* = Result[JsonNode, string]
 
 proc callRpc*(self: StatusObject, rpcMethod: string, params: JsonNode):
   Future[CallRpcResult] {.async.} =
@@ -23,3 +28,34 @@ proc callRpc*(self: StatusObject, rpcMethod: string, params: JsonNode):
     return CallRpcResult.ok await self.web3.callRpc(rpcMethod, params)
   except CatchableError as e:
     return CallRpcResult.err e.msg
+
+proc sendTransaction*(self: StatusObject, fromAddress: EthAddress, transaction: Transaction, password: string, dir: string):
+  Future[SendTransactionResult] {.async.} =
+  if not self.isLoggedIn:
+    return SendTransactionResult.err "Not logged in. Must be logged in"
+
+  try:
+    let account = self.userDb.getWalletAccount(Address(fromAddress))
+    if account.isNone:
+      return SendTransactionResult.err "Wallet address not found"
+
+    let loadAccountResult = self.accountsGenerator.loadAccount(account.get.address, password,dir)
+    if loadAccountResult.isErr:
+      return SendTransactionResult.err loadAccountResult.error
+
+    let accountResult = self.accountsGenerator.findAccount(loadAccountResult.get.id)
+    if accountResult.isErr:
+      return SendTransactionResult.err accountResult.error
+
+    let
+      settings = self.userDb.getSettings()
+      network = settings.getCurrentNetwork()
+
+    var trx = transaction
+    trx.chainId = ChainId(network.get.config.networkId)
+    signTransaction(trx, PrivateKey(accountResult.get.secretKey))
+    let rawTransaction = "0x" & rlp.encode(trx).toHex
+
+    return SendTransactionResult.ok await self.web3.callRpc(RemoteMethod.eth_sendRawTransaction, %*[rawTransaction])
+  except CatchableError as e:
+    return SendTransactionResult.err e.msg

--- a/status/private/accounts/generator/generator.nim
+++ b/status/private/accounts/generator/generator.nim
@@ -82,7 +82,7 @@ proc deriveChildAccounts(self: Generator, a: Account,
 
   DeriveChildAccountsResult.ok(derived)
 
-proc findAccount(self: Generator, accountId: UUID): AccountResult =
+proc findAccount*(self: Generator, accountId: UUID): AccountResult =
 
   let id = $accountId
   if not self.accounts.hasKey(id):


### PR DESCRIPTION
Example command:
`/trx 0x30575c21a1Ec966Cb06eC9aa3dc697c8dECd0e14 0x0000000000000000000000000000000000000000 0 1 255 10000 0x7f7465737432000000000000000000000000000000000000000000000000000000600057 0 1`

Response from infura:
![image](https://user-images.githubusercontent.com/1106587/129383820-377ad9c7-9e64-4cea-9c31-3405b346dc44.png)

Receiving this message means that Infura understood the raw transaction that was signed and was able to get the `from` address from the signed transaction.