### PR TITLE
feat: allow network to be switched

### DIFF
--- a/examples/client/client.nim
+++ b/examples/client/client.nim
@@ -114,11 +114,11 @@ proc getAssets*(self: Client, owner: Address) {.async.} =
 proc getCustomTokens*(self: Client) {.async.} =
   asyncSpawn getCustomTokens(self.taskRunner, status)
 
-proc getTopics(self: Client): Future[seq[ContentTopic]] {.async, gcsafe.} =
-  return await getTopics(self.taskRunner, status)
-
 proc getPrice*(self: Client, tokenSymbol, fiatCurrency: string) {.async.} =
   asyncSpawn getPrice(self.taskRunner, status, tokenSymbol, fiatCurrency)
+
+proc getTopics(self: Client): Future[seq[ContentTopic]] {.async, gcsafe.} =
+  return await getTopics(self.taskRunner, status)
 
 proc importMnemonic*(self: Client, mnemonic: string, passphrase: string,
   password: string) {.async.} =
@@ -134,6 +134,9 @@ proc leaveTopic*(self: Client, topic: ContentTopic) {.async.} =
 
 proc listAccounts*(self: Client) {.async.} =
   asyncSpawn listAccounts(self.taskRunner, status)
+
+proc listNetworks*(self: Client) {.async.} =
+  asyncSpawn listNetworks(self.taskRunner, status)
 
 proc listWalletAccounts*(self: Client) {.async.} =
   asyncSpawn listWalletAccounts(self.taskRunner, status)
@@ -160,3 +163,6 @@ proc setPriceTimeout*(self: Client, timeout: int) {.async.} =
 
 proc stopContext(self: Client) {.async, gcsafe.} =
   await stopContext(self.taskRunner, status)
+
+proc switchNetwork*(self: Client, networkId: string) {.async.} =
+  asyncSpawn switchNetwork(self.taskRunner, status, networkId)

--- a/examples/client/client/events.nim
+++ b/examples/client/client/events.nim
@@ -1,5 +1,5 @@
 import # status lib
-  status/api/[accounts, opensea, tokens, wallet]
+  status/api/[accounts, networks, opensea, tokens, wallet]
 
 import # client modules
   ./common
@@ -68,6 +68,10 @@ type
     accounts*: seq[PublicAccount]
     error*: string
 
+  ListNetworksEvent* = ref object of ClientEvent
+    networks*: seq[Network]
+    error*: string
+
   ListWalletAccountsEvent* = ref object of ClientEvent
     accounts*: seq[WalletAccount]
     error*: string
@@ -97,6 +101,10 @@ type
     error*: string
     timeout*: int
 
+  SwitchNetworkEvent* = ref object of ClientEvent
+    error*: string
+    networkId*: string
+
   UserMessageEvent* = ref object of ClientEvent
     message*: string
     topic*: ContentTopic
@@ -117,12 +125,14 @@ const
     "JoinTopicEvent",
     "LeaveTopicEvent",
     "ListAccountsEvent",
+    "ListNetworksEvent",
     "ListWalletAccountsEvent",
     "LoginEvent",
     "LogoutEvent",
     "SendMessageEvent",
     "SendTransactionEvent",
     "SetPriceTimeoutEvent",
+    "SwitchNetworkEvent",
     "UserMessageEvent",
     "WakuConnectionEvent"
   ]

--- a/examples/client/tui/common.nim
+++ b/examples/client/tui/common.nim
@@ -29,14 +29,14 @@ type
 
   TuiEvent* = ref object of Event
 
-  InputKey* = ref object of TuiEvent
+  InputKeyEvent* = ref object of TuiEvent
     key*: int
     name*: string
 
-  InputReady* = ref object of TuiEvent
+  InputReadyEvent* = ref object of TuiEvent
     ready*: bool
 
-  InputString* = ref object of TuiEvent
+  InputStringEvent* = ref object of TuiEvent
     str*: string
 
   # all fields on types that derive from Command should be of type `string`
@@ -121,6 +121,8 @@ type
 
   ListAccounts* = ref object of Command
 
+  ListNetworks* = ref object of Command
+
   ListWalletAccounts* = ref object of Command
 
   ListTopics* = ref object of Command
@@ -150,6 +152,9 @@ type
   SetPriceTimeout* = ref object of Command
     timeout*: string
 
+  SwitchNetwork* = ref object of Command
+    networkId*: string
+
   SwitchTopic* = ref object of Command
     topic*: string
 
@@ -158,9 +163,9 @@ const
   RETURN* = "RETURN"
 
   TuiEvents* = [
-    "InputKey",
-    "InputReady",
-    "InputString"
+    "InputKeyEvent",
+    "InputReadyEvent",
+    "InputStringEvent"
   ]
 
   DEFAULT_COMMAND* = ""
@@ -186,6 +191,7 @@ const
     "jointopic": "JoinTopic",
     "leavetopic": "LeaveTopic",
     "listaccounts": "ListAccounts",
+    "listnetworks": "ListNetworks",
     "listwalletaccounts": "ListWalletAccounts",
     "listtopics": "ListTopics",
     "login": "Login",
@@ -193,7 +199,7 @@ const
     "quit": "Quit",
     "sendtransaction": "SendTransaction",
     "setpricetimeout": "SetPriceTimeout",
-    "quit": "Quit",
+    "switchnetwork": "SwitchNetwork",
     "switchtopic": "SwitchTopic"
   }.toTable
 
@@ -218,12 +224,14 @@ const
     "leavepublicchat": "leavetopic",
     "list": "listaccounts",
     "listwallets": "listwalletaccounts",
+    "networks": "listnetworks",
     "part": "leavetopic",
     "rpc": "call",
     "send": DEFAULT_COMMAND,
     "sub": "jointopic",
     "subscribe": "jointopic",
     "switch": "switchtopic",
+    "tokens": "getcustomtokens",
     "topics": "listtopics",
     "trx": "sendtransaction",
     "unjoin": "leavetopic",
@@ -244,13 +252,14 @@ const
     "deletecustomtoken": @["deletetoken"],
     "deletewalletaccount": @["delete"],
     "getassets": @["assets"],
-    "getcustomtokens": @["gettokens"],
+    "getcustomtokens": @["gettokens", "tokens"],
     "importmnemonic": @["import"],
     "help": @["?"],
     "jointopic": @["join", "joinpublic", "joinpublicchat", "sub", "subscribe"],
     "leavetopic": @["leave", "leavepublic", "leavepublicchat", "part", "unjoin",
       "unsub", "unsubscribe"],
     "listaccounts": @["list"],
+    "listnetworks": @["networks"],
     "listtopics": @["topics"],
     "listwalletaccounts": @["listwallets", "wallets"],
     "sendtransaction": @["trx"],

--- a/examples/client/tui/tasks.nim
+++ b/examples/client/tui/tasks.nim
@@ -19,7 +19,7 @@ proc readInput*() {.task(kind=no_rts, stoppable=false).} =
     input = 0
 
   let
-    event = InputReady(ready: true)
+    event = InputReadyEvent(ready: true)
     eventEnc = event.encode
 
   trace "task sent event to host", event=eventEnc, task
@@ -45,23 +45,23 @@ proc readInput*() {.task(kind=no_rts, stoppable=false).} =
         shouldSend = false
       if input > 255 or input == 8 or input == 10 or input == 27 or
          input == 127:
-        var event: InputKey
+        var event: InputKeyEvent
         if input == 8:
           # interpret as backspace key
-          event = InputKey(key: 263, name: $keyname(263.cint))
+          event = InputKeyEvent(key: 263, name: $keyname(263.cint))
         elif input == 10:
-          event = InputKey(key: input, name: RETURN)
+          event = InputKeyEvent(key: input, name: RETURN)
         elif input == 27:
-          event = InputKey(key: input, name: ESCAPE)
+          event = InputKeyEvent(key: input, name: ESCAPE)
         elif input == 127:
           if defined(macosx):
             # interpret as backspace key
-            event = InputKey(key: 263, name: $keyname(263.cint))
+            event = InputKeyEvent(key: 263, name: $keyname(263.cint))
           else:
             # interpret as delete key
-            event = InputKey(key: 330, name: $keyname(330.cint))
+            event = InputKeyEvent(key: 330, name: $keyname(330.cint))
         else:
-          event = InputKey(key: input, name: $keyname(input.cint))
+          event = InputKeyEvent(key: input, name: $keyname(input.cint))
         eventEnc = event.encode
         shouldSend = true
 
@@ -78,7 +78,7 @@ proc readInput*() {.task(kind=no_rts, stoppable=false).} =
         got = got + 1
 
         if got == expected:
-          let event = InputString(
+          let event = InputStringEvent(
             str: string.fromBytes(bytes[0..(expected - 1)]))
           eventEnc = event.encode
           shouldSend = true

--- a/status/api/networks.nim
+++ b/status/api/networks.nim
@@ -1,0 +1,52 @@
+{.push raises: [Defect].}
+
+import # std libs
+  std/sugar
+
+import # nim-status modules
+  ../private/[networks, settings, util],
+  ./common
+
+export Network
+
+type
+  NetworksError* = enum
+    GetNetworksError          = "nets: error retrieving networks from settings"
+    MustBeLoggedIn            = "nets: operation not permitted, must be " &
+                                "logged in"
+    NetworkDoesntExist        = "nets: network with specified ID doesn't exist"
+    UpdateNetworkSettingError = "nets: error updating current network setting"
+    UserDbError               = "nets: user db error, must be logged in"
+
+  NetworksResult*[T] = Result[T, NetworksError]
+
+proc getNetworks*(self: StatusObject): NetworksResult[seq[Network]] =
+
+  if self.loginState != LoginState.loggedin:
+    return err MustBeLoggedIn
+
+  let
+    userDb = ?self.userDb.mapErrTo(UserDbError)
+    networks = ?userDb.getSetting(seq[Network], SettingsCol.Networks, @[])
+      .mapErrTo(GetNetworksError)
+
+  ok networks
+
+proc switchNetwork*(self: StatusObject, networkId: string):
+  NetworksResult[void] =
+
+  if self.loginState != LoginState.loggedin:
+    return err MustBeLoggedIn
+
+  let
+    userDb = ?self.userDb.mapErrTo(UserDbError)
+    networks = ?userDb.getSetting(seq[Network], SettingsCol.Networks, @[])
+      .mapErrTo(GetNetworksError)
+
+  if not networks.contains((n: Network) => n.id == networkId):
+    return err NetworkDoesntExist
+
+  ?userDb.saveSetting(SettingsCol.CurrentNetwork, networkId).mapErrTo(
+    UpdateNetworkSettingError)
+
+  ok()

--- a/status/private/settings.nim
+++ b/status/private/settings.nim
@@ -95,6 +95,7 @@ proc getSetting*[T](db: DbConn, _: typedesc[T], setting: SettingsCol):
                       WHERE     synthetic_id = 'id'"""
 
     ok db.value(T, query)
+  except SerializationError: err DataAndTypeMismatch
   except SqliteError: err OperationError
   except ValueError: err QueryBuildError
 

--- a/status/private/util.nim
+++ b/status/private/util.nim
@@ -1,7 +1,7 @@
 {.push raises: [Defect].}
 
 import # std libs
-  std/[re, sets, strutils, tables, unicode]
+  std/[options, re, sets, sequtils, strutils, sugar, tables, unicode]
 
 import # vendor libs
   nimcrypto, stew/results, web3/ethtypes
@@ -30,6 +30,14 @@ template catchEx*(body: typed): Result[type(body), ref Exception] =
     raise d
   except Exception as e:
     R.err(e)
+
+proc find*[T](s: seq[T], pred: (T) -> bool): Option[T] =
+  let filtered = s.filter(pred)
+  if filtered.len == 0:
+    return T.none
+  return filtered[0].some
+
+proc contains*[T](s: seq[T], pred: (T) -> bool): bool = s.find(pred).isSome
 
 proc isHexString*(str: string): UtilResult[bool] {.raises: [].} =
   try:

--- a/test/api/networks.nim
+++ b/test/api/networks.nim
@@ -1,0 +1,108 @@
+import # std libs
+  std/[json, options, os, unittest]
+
+import # vendor libs
+  chronos, json_serialization, sqlcipher
+
+import # status lib
+  status/api/[accounts, auth, common, networks],
+  status/private/settings
+
+import # test modules
+  ../test_helpers
+
+procSuite "networks api integration tests":
+  asyncTest "get networks":
+
+    let
+      dataDir = currentSourcePath.parentDir().parentDir() / "build" / "data"
+      password = "qwerty"
+
+    let statusObjResult = StatusObject.new(dataDir)
+    check statusObjResult.isOk
+    let statusObj = statusObjResult.get
+
+    let createAcctResult = statusObj.createAccount(12, "", password, dataDir)
+    check: createAcctResult.isOk
+    let account = createAcctResult.get
+
+    # check that we can't get networks when not logged in
+    var getNetworksResult = statusObj.getNetworks
+    check:
+      getNetworksResult.isErr
+      getNetworksResult.error == NetworksError.MustBeLoggedIn
+
+    # do login
+    let loginResult = statusObj.login(account.keyUid, password)
+    check: loginResult.isOk
+
+    # check that getting networks works
+    getNetworksResult = statusObj.getNetworks
+    check:
+      getNetworksResult.isOk
+      getNetworksResult.get.len == DEFAULT_NETWORKS.len
+
+    check statusObj.close.isOk
+    removeDir(datadir)
+
+  asyncTest "switch network":
+
+    let
+      dataDir = currentSourcePath.parentDir().parentDir() / "build" / "data"
+      password = "qwerty"
+
+    let statusObjResult = StatusObject.new(dataDir)
+    check statusObjResult.isOk
+    let statusObj = statusObjResult.get
+
+    let createAcctResult = statusObj.createAccount(12, "", password, dataDir)
+    check: createAcctResult.isOk
+    let account = createAcctResult.get
+
+    # check that we can't switch networks when not logged in
+    var switchNetworkResult = statusObj.switchNetwork("not_logged_in")
+    check:
+      switchNetworkResult.isErr
+      switchNetworkResult.error == NetworksError.MustBeLoggedIn
+
+    # do login
+    let loginResult = statusObj.login(account.keyUid, password)
+    check: loginResult.isOk
+
+    # get userDb instance
+    let userDbResult = statusObj.userDb
+    check: userDbResult.isOk
+    let userDb = userDbResult.get
+
+    # check default current network is correct
+    var currentNetwork = userDb.getSetting(string, SettingsCol.CurrentNetwork)
+    check:
+      currentNetwork.isOk
+      currentNetwork.get.isSome
+      currentNetwork.get.get == DEFAULT_NETWORK_NAME
+
+    # check that we can't switch to an unknown network
+    switchNetworkResult = statusObj.switchNetwork("doesnt_exist")
+    check:
+      switchNetworkResult.isErr
+      switchNetworkResult.error == NetworkDoesntExist
+
+    # check that the current network hasn't changed
+    currentNetwork = userDb.getSetting(string, SettingsCol.CurrentNetwork)
+    check:
+      currentNetwork.isOk
+      currentNetwork.get.isSome
+      currentNetwork.get.get == DEFAULT_NETWORK_NAME
+
+    # check that switching networks works
+    let newNetworkId = "testnet_rpc"
+    switchNetworkResult = statusObj.switchNetwork(newNetworkId)
+    currentNetwork = userDb.getSetting(string, SettingsCol.CurrentNetwork)
+    check:
+      switchNetworkResult.isOk
+      currentNetwork.isOk
+      currentNetwork.get.isSome
+      currentNetwork.get.get == newNetworkId
+
+    check statusObj.close.isOk
+    removeDir(datadir)

--- a/test/test_all.nim
+++ b/test/test_all.nim
@@ -3,6 +3,7 @@ import # test modules
   ./accounts/accounts,
   ./accounts/public_accounts,
   ./api,
+  ./api/networks,
   ./bip32,
   ./callrpc,
   ./chats,


### PR DESCRIPTION
Closes: #278.

Add `/switchnetwork` command that allows a user to switch their upstream RPC network.

feat: add /listnetworks command (aliased to `/networks`)
Lists all upstream networks from settings.

Also included in this PR is some alphabetical reorganisation.

NOTE: this PR could be squashed before merge.